### PR TITLE
substituindo query Firestore no login por Cloud Function getUserData

### DIFF
--- a/firebase/functions/src/index.ts
+++ b/firebase/functions/src/index.ts
@@ -3,6 +3,7 @@ import {initializeApp} from "firebase-admin/app";
 initializeApp();
 
 export {createUser} from "./users/handlers/registerUser";
+export {getUserData} from "./users/handlers/getUserData";
 export {getStartups} from "./startups/handlers/getStartups";
 export {getStartupById} from "./startups/handlers/getStartupById";
 export {createFaq} from "./startups/handlers/createFaq";

--- a/firebase/functions/src/users/handlers/getUserData.ts
+++ b/firebase/functions/src/users/handlers/getUserData.ts
@@ -1,0 +1,21 @@
+// Autor: Gustavo Alves de Siqueira Costa
+// Data: 05/05/2026
+// Retorna os dados do usuário autenticado a partir do Firestore
+
+import {onCall, HttpsError} from "firebase-functions/v2/https";
+import {getFirestore} from "firebase-admin/firestore";
+
+export const getUserData = onCall(async (request) => {
+  if (!request.auth) {
+    throw new HttpsError("unauthenticated", "Usuário não autenticado");
+  }
+
+  const uid = request.auth.uid;
+  const doc = await getFirestore().collection("users").doc(uid).get();
+
+  if (!doc.exists) {
+    throw new HttpsError("not-found", "Usuário não encontrado");
+  }
+
+  return doc.data();
+});

--- a/frontend/lib/src/services/auth_service.dart
+++ b/frontend/lib/src/services/auth_service.dart
@@ -1,10 +1,6 @@
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:cloud_functions/cloud_functions.dart';
 
-// ****** REMOVER E ALTERAR A LOGICA *********
-import 'package:cloud_firestore/cloud_firestore.dart'; 
-// *******************************************
-
 class AuthService {
   static Map<String, dynamic> validarDados({
     required String rg,
@@ -209,12 +205,12 @@ class AuthService {
         };
       }
 
-      final userDoc = await FirebaseFirestore.instance
-          .collection('users')
-          .doc(user.uid)
-          .get();
+      final result = await FirebaseFunctions.instance
+          .httpsCallable('getUserData')
+          .call();
 
-      final userData = userDoc.data() ?? {};
+      final userData =
+          Map<String, dynamic>.from(result.data as Map? ?? {});
 
       return {
         'success': true,
@@ -245,7 +241,7 @@ class AuthService {
         'error': e.code,
         'message': message,
       };
-    } on FirebaseException catch (e) {
+    } on FirebaseFunctionsException catch (e) {
       return {
         'success': false,
         'error': e.code,


### PR DESCRIPTION
Remove acesso direto ao Firestore no frontend (auth_service.dart) e adiciona Cloud Function getUserData que retorna os dados do usuário autenticado via request.auth.uid.