### PR TITLE
refactor: centralizar instancia do Firestore em shared/firebase.ts

### DIFF
--- a/firebase/functions/src/shared/firebase.ts
+++ b/firebase/functions/src/shared/firebase.ts
@@ -1,8 +1,7 @@
 // Autor: Gustavo Alves de Siqueira Costa
 // Data: 23/04/2026
-// Descrição: Configuração do Firestore compartilhada
+// Descrição: Instância compartilhada do Firestore
 
-// shared/firebase.ts
-import * as admin from "firebase-admin";
+import {getFirestore} from "firebase-admin/firestore";
 
-export const db = admin.firestore();
+export const db = getFirestore();

--- a/firebase/functions/src/startups/handlers/createFaq.ts
+++ b/firebase/functions/src/startups/handlers/createFaq.ts
@@ -3,8 +3,8 @@
 // Descrição: Handler para criar uma FAQ em uma startup
 
 import {onCall, HttpsError} from "firebase-functions/v2/https";
-import {getFirestore} from "firebase-admin/firestore";
 import {faqsRepository} from "../repositories/faqsRepository";
+import {getUserById} from "../../users/repositories/userRepository";
 
 export const createFaq = onCall(async (request) => {
   if (!request.auth) {
@@ -23,8 +23,7 @@ export const createFaq = onCall(async (request) => {
   const uid = request.auth.uid;
   const email = request.auth.token.email ?? "";
 
-  const userDoc = await getFirestore()
-    .collection("users").doc(uid).get();
+  const userDoc = await getUserById(uid);
   const nomeUsuario = (userDoc.data()?.name as string) ?? "";
 
   await faqsRepository.create(

--- a/firebase/functions/src/startups/repositories/faqsRepository.ts
+++ b/firebase/functions/src/startups/repositories/faqsRepository.ts
@@ -2,10 +2,9 @@
 // Data: 05/05/2026
 // Descrição: Acesso ao Firestore para FAQs de startups
 
-import {getFirestore, FieldValue} from "firebase-admin/firestore";
+import {FieldValue} from "firebase-admin/firestore";
 import {Faq} from "../types";
-
-const db = getFirestore();
+import {db} from "../../shared/firebase";
 const STARTUPS_COLLECTION = "startups";
 const FAQS_SUBCOLLECTION = "faqs";
 

--- a/firebase/functions/src/startups/repositories/startupRepository.ts
+++ b/firebase/functions/src/startups/repositories/startupRepository.ts
@@ -2,10 +2,8 @@
 // Data: 24/04/2026
 // Descrição: Acesso ao Firestore para busca de startups
 
-import {getFirestore} from "firebase-admin/firestore";
 import {Startup, EstagioStartup} from "../types";
-
-const db = getFirestore();
+import {db} from "../../shared/firebase";
 const STARTUPS_COLLECTION = "startups";
 
 export const startupRepository = {

--- a/firebase/functions/src/tokenOffers/repositories/offersRepository.ts
+++ b/firebase/functions/src/tokenOffers/repositories/offersRepository.ts
@@ -1,6 +1,7 @@
 // Caio Ferreira Polo - 25002823
 
-import {FieldValue, getFirestore} from "firebase-admin/firestore";
+import {FieldValue} from "firebase-admin/firestore";
+import {db} from "../../shared/firebase";
 import {HttpsError} from "firebase-functions/v2/https";
 
 import {
@@ -8,8 +9,6 @@ import {
   BuyTokenOfferResult,
 } from "../types/tokenOfferTypes";
 
-
-const db = getFirestore();
 /**
  * Lists token offers from Firestore.
  * @param {string=} excludeSellerId User id to exclude from results.

--- a/firebase/functions/src/users/handlers/getUserData.ts
+++ b/firebase/functions/src/users/handlers/getUserData.ts
@@ -3,7 +3,7 @@
 // Retorna os dados do usuário autenticado a partir do Firestore
 
 import {onCall, HttpsError} from "firebase-functions/v2/https";
-import {getFirestore} from "firebase-admin/firestore";
+import {getUserById} from "../repositories/userRepository";
 
 export const getUserData = onCall(async (request) => {
   if (!request.auth) {
@@ -11,7 +11,7 @@ export const getUserData = onCall(async (request) => {
   }
 
   const uid = request.auth.uid;
-  const doc = await getFirestore().collection("users").doc(uid).get();
+  const doc = await getUserById(uid);
 
   if (!doc.exists) {
     throw new HttpsError("not-found", "Usuário não encontrado");

--- a/firebase/functions/src/users/repositories/userRepository.ts
+++ b/firebase/functions/src/users/repositories/userRepository.ts
@@ -1,7 +1,6 @@
 // Caio Ferreira Polo 25002823
 
-import {getFirestore} from "firebase-admin/firestore";
-const db = getFirestore();
+import {db} from "../../shared/firebase";
 
 /**
  * Registers a new user in Firestore.
@@ -36,6 +35,16 @@ export async function registerUser(
   });
   await batch.commit();
   return uid;
+}
+
+
+/**
+ * Returns a user document by UID.
+ * @param {string} uid User ID.
+ * @return {Promise<FirebaseFirestore.DocumentSnapshot>} User document.
+ */
+export async function getUserById(uid: string) {
+  return db.collection("users").doc(uid).get();
 }
 
 

--- a/firebase/functions/src/wallet/repositories/walletRepository.ts
+++ b/firebase/functions/src/wallet/repositories/walletRepository.ts
@@ -2,7 +2,7 @@
 // Data: 08/05/2026
 // Descrição: Repository da carteira do usuário
 
-import {getFirestore} from "firebase-admin/firestore";
+import {db} from "../../shared/firebase";
 
 /**
  * Returns wallet balance and portfolio summary for a user.
@@ -10,8 +10,6 @@ import {getFirestore} from "firebase-admin/firestore";
  * @return {Promise<object>} Wallet data.
  */
 export async function getWalletDataByUserId(uid: string) {
-  const db = getFirestore();
-
   const [walletDoc, txSnap] = await Promise.all([
     db.collection("users").doc(uid).collection("wallet").doc("saldo").get(),
     db.collection("token_transactions")
@@ -40,8 +38,6 @@ export async function getWalletDataByUserId(uid: string) {
  * @return {Promise<object>} Transaction list.
  */
 export async function getTransactionHistoryByUserId(uid: string) {
-  const db = getFirestore();
-
   const snapshot = await db
     .collection("token_transactions")
     .where("buyerId", "==", uid)
@@ -70,8 +66,6 @@ export async function getTransactionHistoryByUserId(uid: string) {
  * @return {Promise<object>} Token list.
  */
 export async function getUserTokensByUserId(uid: string) {
-  const db = getFirestore();
-
   const txSnap = await db
     .collection("token_transactions")
     .where("buyerId", "==", uid)


### PR DESCRIPTION
- Todos os repositories importam db de shared/firebase ao inves de chamar getFirestore() individualmente