### PR TITLE
refactor: extrair widgets compartilhados

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,11 @@ ES-PI3-2026-T1-G32/
 │   └── lib/src/
 │       ├── pages/          # Telas da aplicação
 │       ├── services/       # Camada de comunicação com Cloud Functions
-│       └── theme/          # Constantes de cores e tema (AppColors)
+│       ├── theme/          # Constantes de cores e tema (AppColors)
+│       └── widgets/        # Widgets compartilhados entre telas
+│           ├── main_scaffold.dart       # Shell de navegação (IndexedStack + BottomNavigationBar)
+│           ├── user_avatar_menu.dart    # Avatar do usuário com popup de perfil/logout
+│           └── app_loading_indicator.dart  # Indicador de carregamento centralizado
 │
 └── firebase/
     ├── functions/src/      # Cloud Functions (TypeScript)

--- a/frontend/lib/src/pages/auth/login_page.dart
+++ b/frontend/lib/src/pages/auth/login_page.dart
@@ -5,7 +5,7 @@
 import 'package:flutter/material.dart';
 import 'package:mescla_invest/src/theme/app_colors.dart';
 import 'package:mescla_invest/src/services/auth_service.dart';
-import 'package:mescla_invest/src/pages/home/main_scaffold.dart';
+import 'package:mescla_invest/src/widgets/main_scaffold.dart';
 import 'package:mescla_invest/src/pages/auth/password_recovery_page.dart';
 import 'package:mescla_invest/src/pages/auth/two_factor_verify_page.dart';
 import 'package:firebase_auth/firebase_auth.dart';

--- a/frontend/lib/src/pages/auth/two_factor_verify_page.dart
+++ b/frontend/lib/src/pages/auth/two_factor_verify_page.dart
@@ -5,7 +5,7 @@
 import 'package:flutter/material.dart';
 import 'package:mescla_invest/src/theme/app_colors.dart';
 import 'package:firebase_auth/firebase_auth.dart';
-import 'package:mescla_invest/src/pages/home/main_scaffold.dart';
+import 'package:mescla_invest/src/widgets/main_scaffold.dart';
 import 'package:mescla_invest/src/services/auth_service.dart';
 import 'package:mescla_invest/src/services/two_factor_service.dart';
 

--- a/frontend/lib/src/pages/home/balcao_page.dart
+++ b/frontend/lib/src/pages/home/balcao_page.dart
@@ -2,10 +2,10 @@
 // Descrição: Tela do balcão de negociação — listagem e compra de ofertas de tokens
 
 import 'package:flutter/material.dart';
-import 'package:firebase_auth/firebase_auth.dart';
 import 'package:cloud_functions/cloud_functions.dart';
 import 'package:mescla_invest/src/theme/app_colors.dart';
-import '../initial_page.dart';
+import 'package:mescla_invest/src/widgets/user_avatar_menu.dart';
+import 'package:mescla_invest/src/widgets/app_loading_indicator.dart';
 import 'buy_steps_page.dart';
 
 class BalcaoNegociacaoPage extends StatefulWidget {
@@ -31,15 +31,6 @@ class _BalcaoNegociacaoPageState extends State<BalcaoNegociacaoPage>{
   }
   
 
-  Future<void> _logout() async {
-    await FirebaseAuth.instance.signOut();
-    if (!mounted) return;
-    Navigator.pushAndRemoveUntil(
-      context,
-      MaterialPageRoute(builder: (_) => const InitialPage()),
-      (_) => false,
-    );
-  }
 
   Future<void> loadOffers() async{
     // Guard inicial: widget pode ser desmontado antes do primeiro frame (ex: navegação rápida).
@@ -76,10 +67,6 @@ class _BalcaoNegociacaoPageState extends State<BalcaoNegociacaoPage>{
 
   @override
   Widget build(BuildContext context) {
-    final usuario = widget.usuario ?? {};
-    final nome = (usuario['nome'] ?? usuario['name']) as String? ?? '';
-    final inicial = nome.isNotEmpty ? nome[0].toUpperCase() : '?';
-
     return Scaffold(
       backgroundColor: AppColors.branco,
       appBar: AppBar(
@@ -87,60 +74,9 @@ class _BalcaoNegociacaoPageState extends State<BalcaoNegociacaoPage>{
         elevation: 0,
         automaticallyImplyLeading: false,
         actions: [
-          Padding(
-            padding: const EdgeInsets.only(right: 16),
-            child: PopupMenuButton<String>(
-              onSelected: (value) {
-                if (value == 'perfil') {
-                  widget.onTabSwitch?.call(4);
-                } else if (value == 'sair') {
-                  _logout();
-                }
-              },
-              color: AppColors.branco,
-              elevation: 3,
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(12),
-                side: BorderSide(color: AppColors.cinza200),
-              ),
-              itemBuilder: (_) => [
-                const PopupMenuItem(
-                  value: 'perfil',
-                  child: Row(children: [
-                    Icon(Icons.person_outline, size: 20, color: AppColors.preto87),
-                    SizedBox(width: 12),
-                    Text('Meu Perfil'),
-                  ]),
-                ),
-                PopupMenuItem<String>(
-                  enabled: false,
-                  height: 8,
-                  padding: EdgeInsets.zero,
-                  child: Divider(indent: 16, endIndent: 16, thickness: 1, height: 1, color: AppColors.cinza200),
-                ),
-                const PopupMenuItem(
-                  value: 'sair',
-                  child: Row(children: [
-                    Icon(Icons.logout, size: 20, color: AppColors.vermelho),
-                    SizedBox(width: 12),
-                    Text('Sair', style: TextStyle(color: AppColors.vermelho)),
-                  ]),
-                ),
-              ],
-              child: CircleAvatar(
-                radius: 18,
-                backgroundColor: AppColors.azul,
-                child: Text(
-                  inicial,
-                  style: const TextStyle(
-                    inherit: false,
-                    color: AppColors.branco,
-                    fontWeight: FontWeight.bold,
-                    fontSize: 18,
-                  ),
-                ),
-              ),
-            ),
+          UserAvatarMenu(
+            usuario: widget.usuario,
+            onPerfilTap: () => widget.onTabSwitch?.call(4),
           ),
         ],
       ),
@@ -192,7 +128,7 @@ class _BalcaoNegociacaoPageState extends State<BalcaoNegociacaoPage>{
               
               Expanded(
                 child: isLoading
-                    ? const Center(child: CircularProgressIndicator(color: AppColors.azul))
+                    ? const AppLoadingIndicator()
                     : errorMessage != null
                     ? Center(child: Text("Erro: $errorMessage", style: _textStyle))
                         : offers.isEmpty

--- a/frontend/lib/src/pages/home/catalog_page.dart
+++ b/frontend/lib/src/pages/home/catalog_page.dart
@@ -4,11 +4,11 @@
 
 import 'package:flutter/material.dart';
 import 'package:mescla_invest/src/theme/app_colors.dart';
-import 'package:firebase_auth/firebase_auth.dart';
 import 'package:intl/intl.dart';
 import 'package:mescla_invest/src/services/startup_service.dart';
 import 'package:mescla_invest/src/pages/home/startup_detail/startup_detail_page.dart';
-import 'package:mescla_invest/src/pages/initial_page.dart';
+import 'package:mescla_invest/src/widgets/user_avatar_menu.dart';
+import 'package:mescla_invest/src/widgets/app_loading_indicator.dart';
 
 const Map<String, String> _estagioLabels = {
   'nova': 'Nova',
@@ -60,19 +60,6 @@ class _InitialCatalogPageState extends State<InitialCatalogPage> {
     super.dispose();
   }
 
-  // Faz logout do Firebase e retorna para a tela inicial, removendo todo o histórico
-  // de navegação para que o botão "voltar" não traga o usuário de volta ao app.
-  Future<void> _logout() async {
-    await FirebaseAuth.instance.signOut();
-    if (!mounted) return;
-    // pushAndRemoveUntil remove todas as rotas anteriores da pilha de navegação.
-    Navigator.pushAndRemoveUntil(
-      context,
-      MaterialPageRoute(builder: (_) => const InitialPage()),
-      (_) => false,
-    );
-  }
-
   Future<void> fetchStartups() async {
     // Guard contra race condition: se o usuário troca o filtro rapidamente,
     // descartamos respostas de requisições antigas que chegarem depois.
@@ -117,10 +104,6 @@ class _InitialCatalogPageState extends State<InitialCatalogPage> {
 
   @override
   Widget build(BuildContext context) {
-    final usuario = widget.usuario ?? {};
-    final nome = (usuario['nome'] ?? usuario['name']) as String? ?? '';
-    final inicial = nome.isNotEmpty ? nome[0].toUpperCase() : '?';
-
     return Scaffold(
       backgroundColor: AppColors.cinza100,
 
@@ -129,64 +112,12 @@ class _InitialCatalogPageState extends State<InitialCatalogPage> {
         elevation: 0,
         automaticallyImplyLeading: false,
         actions: [
-          Padding(
-            padding: const EdgeInsets.only(right: 16),
-            child: PopupMenuButton<String>(
-              onSelected: (value) {
-                if (value == 'perfil') {
-                  widget.onTabSwitch?.call(4);
-                } else if (value == 'sair') {
-                  _logout();
-                }
-              },
-              color: AppColors.branco,
-              elevation: 3,
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(12),
-                side: BorderSide(color: AppColors.cinza200),
-              ),
-              itemBuilder: (_) => [
-                const PopupMenuItem(
-                  value: 'perfil',
-                  child: Row(children: [
-                    Icon(Icons.person_outline, size: 20, color: AppColors.preto87),
-                    SizedBox(width: 12),
-                    Text('Meu Perfil'),
-                  ]),
-                ),
-                PopupMenuItem<String>(
-                  enabled: false,
-                  height: 8,
-                  padding: EdgeInsets.zero,
-                  child: Divider(indent: 16, endIndent: 16, thickness: 1, height: 1, color: AppColors.cinza200),
-                ),
-                const PopupMenuItem(
-                  value: 'sair',
-                  child: Row(children: [
-                    Icon(Icons.logout, size: 20, color: AppColors.vermelho),
-                    SizedBox(width: 12),
-                    Text('Sair', style: TextStyle(color: AppColors.vermelho)),
-                  ]),
-                ),
-              ],
-              child: CircleAvatar(
-                radius: 18,
-                backgroundColor: AppColors.azul,
-                child: Text(
-                  inicial,
-                  style: const TextStyle(
-                    inherit: false,
-                    color: AppColors.branco,
-                    fontWeight: FontWeight.bold,
-                    fontSize: 18,
-                  ),
-                ),
-              ),
-            ),
+          UserAvatarMenu(
+            usuario: widget.usuario,
+            onPerfilTap: () => widget.onTabSwitch?.call(4),
           ),
         ],
       ),
-
       body: SafeArea(
         child: Padding(
           padding: const EdgeInsets.symmetric(horizontal: 20),
@@ -249,7 +180,7 @@ class _InitialCatalogPageState extends State<InitialCatalogPage> {
               // Lista de startups
               Expanded(
                 child: isLoading
-                    ? const Center(child: CircularProgressIndicator(color: AppColors.azul))
+                    ? const AppLoadingIndicator()
                     : error != null
                         ? Center(child: Text("Erro: $error"))
                         : _filteredStartups.isEmpty

--- a/frontend/lib/src/pages/home/home_page.dart
+++ b/frontend/lib/src/pages/home/home_page.dart
@@ -3,13 +3,13 @@
 // Descrição: Tela inicial pós-login com resumo financeiro e startups em destaque
 
 import 'package:flutter/material.dart';
-import 'package:firebase_auth/firebase_auth.dart';
 import 'package:intl/intl.dart';
 import 'package:mescla_invest/src/theme/app_colors.dart';
 import 'package:mescla_invest/src/services/wallet_service.dart';
 import 'package:mescla_invest/src/services/startup_service.dart';
-import 'package:mescla_invest/src/pages/initial_page.dart';
 import 'package:mescla_invest/src/pages/home/startup_detail/startup_detail_page.dart';
+import 'package:mescla_invest/src/widgets/user_avatar_menu.dart';
+import 'package:mescla_invest/src/widgets/app_loading_indicator.dart';
 
 class HomePage extends StatefulWidget {
   final Map<String, dynamic>? usuario;
@@ -72,21 +72,10 @@ class _HomePageState extends State<HomePage> {
     setState(() => _isLoading = false);
   }
 
-  Future<void> _logout() async {
-    await FirebaseAuth.instance.signOut();
-    if (!mounted) return;
-    Navigator.pushAndRemoveUntil(
-      context,
-      MaterialPageRoute(builder: (_) => const InitialPage()),
-      (_) => false,
-    );
-  }
-
   @override
   Widget build(BuildContext context) {
     final usuario = widget.usuario ?? {};
     final nome = (usuario['nome'] ?? usuario['name']) as String? ?? '';
-    final inicial = nome.isNotEmpty ? nome[0].toUpperCase() : '?';
     final primeiroNome = nome.split(' ').first;
 
     return Scaffold(
@@ -96,60 +85,9 @@ class _HomePageState extends State<HomePage> {
         elevation: 0,
         automaticallyImplyLeading: false,
         actions: [
-          Padding(
-            padding: const EdgeInsets.only(right: 16),
-            child: PopupMenuButton<String>(
-              onSelected: (value) {
-                if (value == 'perfil') {
-                  widget.onTabSwitch?.call(4);
-                } else if (value == 'sair') {
-                  _logout();
-                }
-              },
-              color: AppColors.branco,
-              elevation: 3,
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(12),
-                side: BorderSide(color: AppColors.cinza200),
-              ),
-              itemBuilder: (_) => [
-                const PopupMenuItem(
-                  value: 'perfil',
-                  child: Row(children: [
-                    Icon(Icons.person_outline, size: 20, color: AppColors.preto87),
-                    SizedBox(width: 12),
-                    Text('Meu Perfil'),
-                  ]),
-                ),
-                PopupMenuItem<String>(
-                  enabled: false,
-                  height: 8,
-                  padding: EdgeInsets.zero,
-                  child: Divider(indent: 16, endIndent: 16, thickness: 1, height: 1, color: AppColors.cinza200),
-                ),
-                const PopupMenuItem(
-                  value: 'sair',
-                  child: Row(children: [
-                    Icon(Icons.logout, size: 20, color: AppColors.vermelho),
-                    SizedBox(width: 12),
-                    Text('Sair', style: TextStyle(color: AppColors.vermelho)),
-                  ]),
-                ),
-              ],
-              child: CircleAvatar(
-                radius: 18,
-                backgroundColor: AppColors.azul,
-                child: Text(
-                  inicial,
-                  style: const TextStyle(
-                    inherit: false,
-                    color: AppColors.branco,
-                    fontWeight: FontWeight.bold,
-                    fontSize: 18,
-                  ),
-                ),
-              ),
-            ),
+          UserAvatarMenu(
+            usuario: widget.usuario,
+            onPerfilTap: () => widget.onTabSwitch?.call(4),
           ),
         ],
       ),
@@ -302,7 +240,7 @@ class _HomePageState extends State<HomePage> {
             const SizedBox(height: 12),
 
             if (_isLoading)
-              const Center(child: CircularProgressIndicator(color: AppColors.azul))
+              const AppLoadingIndicator()
             else if (_destaques.isEmpty)
               const Text(
                 'Nenhuma startup disponível',

--- a/frontend/lib/src/pages/home/startup_detail/startup_detail_page.dart
+++ b/frontend/lib/src/pages/home/startup_detail/startup_detail_page.dart
@@ -3,13 +3,13 @@
 // Descrição: Tela de detalhes de uma startup
 
 import 'package:flutter/material.dart';
-import 'package:firebase_auth/firebase_auth.dart';
 import 'package:mescla_invest/src/theme/app_colors.dart';
 import 'package:mescla_invest/src/services/startup_service.dart';
 import 'package:mescla_invest/src/services/faq_service.dart';
 import 'package:mescla_invest/src/pages/home/startup_detail/startup_detail_widgets.dart';
 import 'package:mescla_invest/src/pages/home/startup_detail/startup_detail_faq.dart';
-import 'package:mescla_invest/src/pages/initial_page.dart';
+import 'package:mescla_invest/src/widgets/user_avatar_menu.dart';
+import 'package:mescla_invest/src/widgets/app_loading_indicator.dart';
 
 class StartupDetailPage extends StatefulWidget {
   final String startupId;
@@ -48,17 +48,6 @@ class _StartupDetailPageState extends State<StartupDetailPage> {
     // Carrega dados da startup e FAQs em paralelo ao abrir a tela.
     _fetchDetail();
     _loadFaqs();
-  }
-
-  // Faz logout e remove toda a pilha de navegação, retornando à tela inicial.
-  Future<void> _logout() async {
-    await FirebaseAuth.instance.signOut();
-    if (!mounted) return;
-    Navigator.pushAndRemoveUntil(
-      context,
-      MaterialPageRoute(builder: (_) => const InitialPage()),
-      (_) => false,
-    );
   }
 
   // Busca as FAQs da startup via Cloud Function.
@@ -104,10 +93,6 @@ class _StartupDetailPageState extends State<StartupDetailPage> {
 
   @override
   Widget build(BuildContext context) {
-    final usuario = widget.usuario ?? {};
-    final nome = (usuario['nome'] ?? usuario['name']) as String? ?? '';
-    final inicial = nome.isNotEmpty ? nome[0].toUpperCase() : '?';
-
     return Scaffold(
       backgroundColor: AppColors.branco,
       appBar: AppBar(
@@ -123,66 +108,17 @@ class _StartupDetailPageState extends State<StartupDetailPage> {
         ),
         centerTitle: true,
         actions: [
-          Padding(
-            padding: const EdgeInsets.only(right: 16),
-            child: PopupMenuButton<String>(
-              onSelected: (value) {
-                if (value == 'perfil') {
-                  Navigator.pop(context);
-                  widget.onTabSwitch?.call(4);
-                } else if (value == 'sair') {
-                  _logout();
-                }
-              },
-              color: AppColors.branco,
-              elevation: 3,
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(12),
-                side: BorderSide(color: AppColors.cinza200),
-              ),
-              itemBuilder: (_) => [
-                const PopupMenuItem(
-                  value: 'perfil',
-                  child: Row(children: [
-                    Icon(Icons.person_outline, size: 20, color: AppColors.preto87),
-                    SizedBox(width: 12),
-                    Text('Meu Perfil'),
-                  ]),
-                ),
-                PopupMenuItem<String>(
-                  enabled: false,
-                  height: 8,
-                  padding: EdgeInsets.zero,
-                  child: Divider(indent: 16, endIndent: 16, thickness: 1, height: 1, color: AppColors.cinza200),
-                ),
-                const PopupMenuItem(
-                  value: 'sair',
-                  child: Row(children: [
-                    Icon(Icons.logout, size: 20, color: AppColors.vermelho),
-                    SizedBox(width: 12),
-                    Text('Sair', style: TextStyle(color: AppColors.vermelho)),
-                  ]),
-                ),
-              ],
-              child: CircleAvatar(
-                radius: 18,
-                backgroundColor: AppColors.azul,
-                child: Text(
-                  inicial,
-                  style: const TextStyle(
-                    inherit: false,
-                    color: AppColors.branco,
-                    fontWeight: FontWeight.bold,
-                    fontSize: 18,
-                  ),
-                ),
-              ),
-            ),
+          UserAvatarMenu(
+            usuario: widget.usuario,
+            onPerfilTap: () {
+              Navigator.pop(context);
+              widget.onTabSwitch?.call(4);
+            },
           ),
         ],
       ),
       body: isLoading
-          ? const Center(child: CircularProgressIndicator(color: AppColors.azul))
+          ? const AppLoadingIndicator()
           : error != null
               ? Center(child: Text('Erro: $error'))
               : Column(
@@ -356,7 +292,7 @@ class _StartupDetailPageState extends State<StartupDetailPage> {
           const SizedBox(height: 16),
 
           if (_faqsLoading)
-            const Center(child: CircularProgressIndicator(color: AppColors.azul))
+            const AppLoadingIndicator()
           else if (_faqs.isEmpty)
             Center(child: Text('Nenhuma pergunta ainda', style: TextStyle(color: AppColors.cinza400)))
           else

--- a/frontend/lib/src/pages/home/wallet_page.dart
+++ b/frontend/lib/src/pages/home/wallet_page.dart
@@ -3,10 +3,10 @@
 // Descrição: Tela de carteira do usuário
 
 import 'package:flutter/material.dart';
-import 'package:firebase_auth/firebase_auth.dart';
 import 'package:mescla_invest/src/theme/app_colors.dart';
 import 'package:mescla_invest/src/services/wallet_service.dart';
-import 'package:mescla_invest/src/pages/initial_page.dart';
+import 'package:mescla_invest/src/widgets/user_avatar_menu.dart';
+import 'package:mescla_invest/src/widgets/app_loading_indicator.dart';
 import 'package:intl/intl.dart';
 
 class WalletPage extends StatefulWidget {
@@ -39,16 +39,6 @@ class _WalletPageState extends State<WalletPage>
     super.initState();
     _tabController = TabController(length: 2, vsync: this);
     _loadAll();
-  }
-
-  Future<void> _logout() async {
-    await FirebaseAuth.instance.signOut();
-    if (!mounted) return;
-    Navigator.pushAndRemoveUntil(
-      context,
-      MaterialPageRoute(builder: (_) => const InitialPage()),
-      (_) => false,
-    );
   }
 
   Future<void> _loadAll() async {
@@ -105,10 +95,6 @@ class _WalletPageState extends State<WalletPage>
 
   @override
   Widget build(BuildContext context) {
-    final usuario = widget.usuario ?? {};
-    final nome = (usuario['nome'] ?? usuario['name']) as String? ?? '';
-    final inicial = nome.isNotEmpty ? nome[0].toUpperCase() : '?';
-
     return Scaffold(
       backgroundColor: AppColors.branco,
       appBar: AppBar(
@@ -124,65 +110,14 @@ class _WalletPageState extends State<WalletPage>
           ),
         ),
         actions: [
-          Padding(
-            padding: const EdgeInsets.only(right: 16),
-            child: PopupMenuButton<String>(
-              onSelected: (value) {
-                if (value == 'perfil') {
-                  widget.onTabSwitch?.call(4);
-                } else if (value == 'sair') {
-                  _logout();
-                }
-              },
-              color: AppColors.branco,
-              elevation: 3,
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(12),
-                side: BorderSide(color: AppColors.cinza200),
-              ),
-              itemBuilder: (_) => [
-                const PopupMenuItem(
-                  value: 'perfil',
-                  child: Row(children: [
-                    Icon(Icons.person_outline, size: 20, color: AppColors.preto87),
-                    SizedBox(width: 12),
-                    Text('Meu Perfil'),
-                  ]),
-                ),
-                PopupMenuItem<String>(
-                  enabled: false,
-                  height: 8,
-                  padding: EdgeInsets.zero,
-                  child: Divider(indent: 16, endIndent: 16, thickness: 1, height: 1, color: AppColors.cinza200),
-                ),
-                const PopupMenuItem(
-                  value: 'sair',
-                  child: Row(children: [
-                    Icon(Icons.logout, size: 20, color: AppColors.vermelho),
-                    SizedBox(width: 12),
-                    Text('Sair', style: TextStyle(color: AppColors.vermelho)),
-                  ]),
-                ),
-              ],
-              child: CircleAvatar(
-                radius: 18,
-                backgroundColor: AppColors.azul,
-                child: Text(
-                  inicial,
-                  style: const TextStyle(
-                    inherit: false,
-                    color: AppColors.branco,
-                    fontWeight: FontWeight.bold,
-                    fontSize: 18,
-                  ),
-                ),
-              ),
-            ),
+          UserAvatarMenu(
+            usuario: widget.usuario,
+            onPerfilTap: () => widget.onTabSwitch?.call(4),
           ),
         ],
       ),
       body: _isLoading
-          ? const Center(child: CircularProgressIndicator(color: AppColors.azul))
+          ? const AppLoadingIndicator()
           : RefreshIndicator(
               onRefresh: _loadAll,
               child: CustomScrollView(

--- a/frontend/lib/src/widgets/app_loading_indicator.dart
+++ b/frontend/lib/src/widgets/app_loading_indicator.dart
@@ -1,0 +1,14 @@
+// Autor: Gustavo Alves de Siqueira Costa
+// Data: 12/05/2026
+// Descrição: Indicador de carregamento centralizado — reutilizado em todas as telas
+
+import 'package:flutter/material.dart';
+import 'package:mescla_invest/src/theme/app_colors.dart';
+
+class AppLoadingIndicator extends StatelessWidget {
+  const AppLoadingIndicator({super.key});
+
+  @override
+  Widget build(BuildContext context) =>
+      const Center(child: CircularProgressIndicator(color: AppColors.azul));
+}

--- a/frontend/lib/src/widgets/main_scaffold.dart
+++ b/frontend/lib/src/widgets/main_scaffold.dart
@@ -1,0 +1,74 @@
+// Autor: Gustavo Alves de Siqueira Costa
+// Data: 12/05/2026
+// Descrição: Shell de navegação principal — define a BottomNavigationBar uma única vez
+// e usa IndexedStack para preservar o estado de cada aba ao trocar de página.
+
+import 'package:flutter/material.dart';
+import 'package:mescla_invest/src/theme/app_colors.dart';
+import 'package:mescla_invest/src/pages/home/home_page.dart';
+import 'package:mescla_invest/src/pages/home/balcao_page.dart';
+import 'package:mescla_invest/src/pages/home/catalog_page.dart';
+import 'package:mescla_invest/src/pages/home/wallet_page.dart';
+import 'package:mescla_invest/src/pages/home/profile_page.dart';
+
+class MainScaffold extends StatefulWidget {
+  final Map<String, dynamic>? usuario;
+  final int initialIndex;
+
+  const MainScaffold({super.key, this.usuario, this.initialIndex = 0});
+
+  @override
+  State<MainScaffold> createState() => _MainScaffoldState();
+}
+
+class _MainScaffoldState extends State<MainScaffold> {
+  late int _currentIndex;
+
+  @override
+  void initState() {
+    super.initState();
+    _currentIndex = widget.initialIndex;
+  }
+
+  void _switchTab(int index) {
+    setState(() => _currentIndex = index);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: IndexedStack(
+        index: _currentIndex,
+        children: [
+          HomePage(usuario: widget.usuario, onTabSwitch: _switchTab),
+          BalcaoNegociacaoPage(usuario: widget.usuario, onTabSwitch: _switchTab),
+          InitialCatalogPage(usuario: widget.usuario, onTabSwitch: _switchTab),
+          WalletPage(usuario: widget.usuario, onTabSwitch: _switchTab),
+          ProfilePage(usuario: widget.usuario, onTabSwitch: _switchTab),
+        ],
+      ),
+      bottomNavigationBar: Container(
+        decoration: BoxDecoration(
+          color: AppColors.branco,
+          border: Border(top: BorderSide(color: AppColors.cinza300)),
+        ),
+        child: BottomNavigationBar(
+          type: BottomNavigationBarType.fixed,
+          backgroundColor: AppColors.branco,
+          elevation: 0,
+          currentIndex: _currentIndex,
+          selectedItemColor: AppColors.azul,
+          unselectedItemColor: AppColors.cinza500,
+          onTap: _switchTab,
+          items: const [
+            BottomNavigationBarItem(icon: Icon(Icons.home_outlined), label: "Início"),
+            BottomNavigationBarItem(icon: Icon(Icons.store), label: "Mercado"),
+            BottomNavigationBarItem(icon: Icon(Icons.list), label: "Catálogo"),
+            BottomNavigationBarItem(icon: Icon(Icons.account_balance_wallet), label: "Carteira"),
+            BottomNavigationBarItem(icon: Icon(Icons.person_outline), label: "Perfil"),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/lib/src/widgets/user_avatar_menu.dart
+++ b/frontend/lib/src/widgets/user_avatar_menu.dart
@@ -1,0 +1,87 @@
+// Autor: Gustavo Alves de Siqueira Costa
+// Data: 12/05/2026
+// Descrição: Avatar do usuário com menu de contexto — reutilizado em todas as AppBars
+
+import 'package:flutter/material.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:mescla_invest/src/theme/app_colors.dart';
+import 'package:mescla_invest/src/pages/initial_page.dart';
+
+class UserAvatarMenu extends StatelessWidget {
+  final Map<String, dynamic>? usuario;
+  final VoidCallback? onPerfilTap;
+
+  const UserAvatarMenu({super.key, this.usuario, this.onPerfilTap});
+
+  Future<void> _logout(BuildContext context) async {
+    await FirebaseAuth.instance.signOut();
+    if (!context.mounted) return;
+    Navigator.pushAndRemoveUntil(
+      context,
+      MaterialPageRoute(builder: (_) => const InitialPage()),
+      (_) => false,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final nome = ((usuario?['nome'] ?? usuario?['name']) as String?) ?? '';
+    final inicial = nome.isNotEmpty ? nome[0].toUpperCase() : '?';
+
+    return Padding(
+      padding: const EdgeInsets.only(right: 16),
+      child: PopupMenuButton<String>(
+        onSelected: (value) {
+          if (value == 'perfil') {
+            onPerfilTap?.call();
+          } else if (value == 'sair') {
+            _logout(context);
+          }
+        },
+        color: AppColors.branco,
+        elevation: 3,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(12),
+          side: BorderSide(color: AppColors.cinza200),
+        ),
+        itemBuilder: (_) => [
+          const PopupMenuItem(
+            value: 'perfil',
+            child: Row(children: [
+              Icon(Icons.person_outline, size: 20, color: AppColors.preto87),
+              SizedBox(width: 12),
+              Text('Meu Perfil'),
+            ]),
+          ),
+          PopupMenuItem<String>(
+            enabled: false,
+            height: 8,
+            padding: EdgeInsets.zero,
+            child: Divider(indent: 16, endIndent: 16, thickness: 1, height: 1, color: AppColors.cinza200),
+          ),
+          const PopupMenuItem(
+            value: 'sair',
+            child: Row(children: [
+              Icon(Icons.logout, size: 20, color: AppColors.vermelho),
+              SizedBox(width: 12),
+              Text('Sair', style: TextStyle(color: AppColors.vermelho)),
+            ]),
+          ),
+        ],
+        child: CircleAvatar(
+          radius: 18,
+          backgroundColor: AppColors.azul,
+          child: Text(
+            inicial,
+            style: const TextStyle(
+              inherit: false,
+              color: AppColors.branco,
+              fontWeight: FontWeight.bold,
+              fontSize: 18,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
Cria lib/src/widgets/ com três widgets reutilizáveis:
- UserAvatarMenu: popup de perfil/logout extraído de 5 páginas
- AppLoadingIndicator: CircularProgressIndicator centralizado
- MainScaffold: shell de navegacao principal, BottomNavigationBar

Atualiza README com a nova estrutura de widgets.