### PR TITLE
feat: controle de acesso a FAQs privadas por posse de tokens

### DIFF
--- a/firebase/functions/src/modules/startups/handlers/createFaq.ts
+++ b/firebase/functions/src/modules/startups/handlers/createFaq.ts
@@ -6,6 +6,8 @@ import {onCall, HttpsError} from "firebase-functions/v2/https";
 import {faqsRepository} from "../repositories/faqsRepository";
 import {getUserById} from "../../users/repositories/userRepository";
 import {requireAuth} from "../../../shared/validation";
+import {db} from "../../../shared/firebase";
+import {USERS, USER_TOKENS} from "../../../shared/collections";
 
 export const createFaq = onCall(async (request) => {
   requireAuth(request.auth);
@@ -20,9 +22,22 @@ export const createFaq = onCall(async (request) => {
   }
 
   const uid = request.auth.uid;
-  // Email e nome são lidos do token/Firestore e nunca do request.data
-  // para evitar que o cliente envie valores falsos.
-  const email = request.auth.token.email ?? "";
+  const email = request.auth.token.email!;
+
+  if (privada === true) {
+    const tokenDoc = await db
+      .collection(USERS).doc(uid)
+      .collection(USER_TOKENS).doc(startupId)
+      .get();
+    const hasTokens =
+      tokenDoc.exists && Number(tokenDoc.data()?.quantidade ?? 0) > 0;
+    if (!hasTokens) {
+      throw new HttpsError(
+        "permission-denied",
+        "Apenas investidores podem enviar perguntas privadas"
+      );
+    }
+  }
 
   // Nome vem do Firestore (campo 'name') pois o token Auth não o contém.
   const userDoc = await getUserById(uid);

--- a/firebase/functions/src/modules/startups/handlers/getFaqs.ts
+++ b/firebase/functions/src/modules/startups/handlers/getFaqs.ts
@@ -5,6 +5,8 @@
 import {onCall, HttpsError} from "firebase-functions/v2/https";
 import {faqsRepository} from "../repositories/faqsRepository";
 import {requireAuth} from "../../../shared/validation";
+import {db} from "../../../shared/firebase";
+import {USERS, USER_TOKENS} from "../../../shared/collections";
 
 export const getFaqs = onCall(async (request) => {
   requireAuth(request.auth);
@@ -15,11 +17,18 @@ export const getFaqs = onCall(async (request) => {
     throw new HttpsError("invalid-argument", "startupId é obrigatório");
   }
 
-  // Email do token é usado no repository para filtrar FAQs privadas:
-  // o usuário só vê as próprias perguntas privadas.
-  const email = request.auth.token.email ?? "";
+  const uid = request.auth.uid;
+  const email = request.auth.token.email!;
 
-  const faqs = await faqsRepository.findByStartup(startupId, email);
+  const tokenDoc = await db
+    .collection(USERS).doc(uid)
+    .collection(USER_TOKENS).doc(startupId)
+    .get();
+
+  const hasTokens =
+    tokenDoc.exists && Number(tokenDoc.data()?.quantidade ?? 0) > 0;
+
+  const faqs = await faqsRepository.findByStartup(startupId, hasTokens, email);
 
   return {success: true, data: faqs};
 });

--- a/firebase/functions/src/modules/startups/repositories/faqsRepository.ts
+++ b/firebase/functions/src/modules/startups/repositories/faqsRepository.ts
@@ -22,13 +22,18 @@ const docToFaq = (doc: FirebaseFirestore.QueryDocumentSnapshot): Faq => ({
 });
 
 export const faqsRepository = {
-  async findByStartup(startupId: string, userEmail: string): Promise<Faq[]> {
+  async findByStartup(
+    startupId: string,
+    hasTokens: boolean,
+    userEmail: string
+  ): Promise<Faq[]> {
     const snapshot = await faqsRef(startupId).get();
 
-    // FAQs privadas só são visíveis para o próprio autor (via email do token).
+    // Públicas: sempre visíveis.
+    // Privadas: visíveis só para o autor, se ele tiver tokens.
     return snapshot.docs
       .map(docToFaq)
-      .filter((faq) => !faq.privada || faq.email === userEmail)
+      .filter((faq) => !faq.privada || (hasTokens && faq.email === userEmail))
       .sort((a, b) => (b.criadoEm ?? 0) - (a.criadoEm ?? 0));
   },
 

--- a/frontend/lib/src/pages/home/startup_detail/startup_detail_faq.dart
+++ b/frontend/lib/src/pages/home/startup_detail/startup_detail_faq.dart
@@ -14,7 +14,8 @@ class FaqResult {
 
 class FaqDialog extends StatefulWidget {
   final String startupId;
-  const FaqDialog({super.key, required this.startupId});
+  final bool temTokens;
+  const FaqDialog({super.key, required this.startupId, this.temTokens = false});
 
   @override
   State<FaqDialog> createState() => _FaqDialogState();
@@ -81,21 +82,23 @@ class _FaqDialogState extends State<FaqDialog> {
                 ),
               ),
             ),
-            const SizedBox(height: 12),
-            Row(
-              children: [
-                Switch(
-                  value: _privada,
-                  activeThumbColor: AppColors.azul,
-                  activeTrackColor: AppColors.azul200,
-                  inactiveTrackColor: AppColors.cinza200,
-                  inactiveThumbColor: AppColors.cinza500,
-                  onChanged: (v) => setState(() => _privada = v),
-                ),
-                Text(_privada ? 'Privada' : 'Pública',
-                    style: const TextStyle(fontSize: 14)),
-              ],
-            ),
+            if (widget.temTokens) ...[
+              const SizedBox(height: 12),
+              Row(
+                children: [
+                  Switch(
+                    value: _privada,
+                    activeThumbColor: AppColors.azul,
+                    activeTrackColor: AppColors.azul200,
+                    inactiveTrackColor: AppColors.cinza200,
+                    inactiveThumbColor: AppColors.cinza500,
+                    onChanged: (v) => setState(() => _privada = v),
+                  ),
+                  Text(_privada ? 'Privada' : 'Pública',
+                      style: const TextStyle(fontSize: 14)),
+                ],
+              ),
+            ],
           ],
         ),
       ),

--- a/frontend/lib/src/pages/home/startup_detail/startup_detail_page.dart
+++ b/frontend/lib/src/pages/home/startup_detail/startup_detail_page.dart
@@ -86,10 +86,12 @@ class _StartupDetailPageState extends State<StartupDetailPage> {
     if (!mounted || result['success'] != true) return;
     final tokens = List<Map<String, dynamic>>.from(result['tokens'] ?? []);
     final match = tokens.where((t) => t['startupId'] == widget.startupId);
+    final qty = match.isNotEmpty
+        ? (match.first['quantidade'] as num?)?.toInt() ?? 0
+        : 0;
     setState(() {
-      _userTokenQuantity = match.isNotEmpty
-          ? (match.first['quantidade'] as num?)?.toInt() ?? 0
-          : 0;
+      _userTokenQuantity = qty;
+      if (qty == 0 && _faqFilter == 2) _faqFilter = 0;
     });
   }
 
@@ -115,6 +117,7 @@ class _StartupDetailPageState extends State<StartupDetailPage> {
     if (vendeu == true) {
       _houvePurchase = true;
       _loadUserTokens();
+      _loadFaqs();
       _fetchDetail();
     }
   }
@@ -137,7 +140,7 @@ class _StartupDetailPageState extends State<StartupDetailPage> {
   Future<void> _showFaqDialog() async {
     final result = await showDialog<FaqResult>(
       context: context,
-      builder: (_) => FaqDialog(startupId: widget.startupId),
+      builder: (_) => FaqDialog(startupId: widget.startupId, temTokens: _userTokenQuantity > 0),
     );
     // Recarrega as FAQs após o envio. addPostFrameCallback evita chamar setState
     // durante a fase de build que ocorre imediatamente após o pop do dialog.
@@ -202,6 +205,8 @@ class _StartupDetailPageState extends State<StartupDetailPage> {
 
     if (comprou == true) {
       _houvePurchase = true;
+      _loadUserTokens();
+      _loadFaqs();
       _fetchDetail();
     }
   }
@@ -374,6 +379,8 @@ class _StartupDetailPageState extends State<StartupDetailPage> {
             scrollDirection: Axis.horizontal,
             child: Row(
               children: List.generate(_faqFilters.length, (i) {
+                // Esconde o filtro "Privadas" (índice 2) para quem não tem tokens.
+                if (i == 2 && _userTokenQuantity == 0) return const SizedBox.shrink();
                 final selected = _faqFilter == i;
                 return Padding(
                   padding: EdgeInsets.only(right: i < _faqFilters.length - 1 ? 8 : 0),


### PR DESCRIPTION
- Backend valida posse de tokens antes de criar FAQ privada
- getFaqs filtra FAQs privadas: visíveis apenas ao autor com tokens
- FaqDialog exibe switch de privada apenas para investidores
- Recarrega FAQs e tokens após compra/venda; reseta filtro se perder tokens