### PR TITLE
refactor: centraliza cálculo de preço no back e corrige bugs no frontend

### DIFF
--- a/firebase/functions/src/modules/tokenOffers/repositories/cancelOfferRepository.ts
+++ b/firebase/functions/src/modules/tokenOffers/repositories/cancelOfferRepository.ts
@@ -6,13 +6,13 @@ import {HttpsError} from "firebase-functions/v2/https";
 import {db} from "../../../shared/firebase";
 import {
   USERS, TOKEN_OFFERS, USER_TOKENS, STARTUPS, PRICE_HISTORY, TRANSACTIONS,
-  TX_TYPE_RETURN, TX_TYPE_CANCEL_OFFER, TX_SOURCE_SELL_OFFER,
+  TxType, TxSource,
 } from "../../../shared/collections";
 import {
   CancelSellOfferParams,
   CancelSellOfferResult,
 } from "../types/tokenOfferTypes";
-import {FATOR_IMPACTO} from "../../../shared/tokenPricing";
+import {calcularNovoPreco} from "../../../shared/tokenPricing";
 
 /**
  * @param {CancelSellOfferParams} params
@@ -99,7 +99,7 @@ export async function cancelOffer(
 
     // Record the return in transaction history (creates a new lot in portfolio)
     transaction.set(transactionRef, {
-      type: TX_TYPE_RETURN,
+      type: TxType.RETURN,
       buyerId: sellerId,
       startupId,
       startupName,
@@ -114,8 +114,7 @@ export async function cancelOffer(
     if (startupData) {
       const totalTokens = Number(startupData.totalTokens ?? 1000);
       const precoAtual = Number(startupData.precoToken ?? 0);
-      const impacto = (amount / totalTokens) * FATOR_IMPACTO;
-      const precoRevertido = Math.round(precoAtual * (1 + impacto));
+      const precoRevertido = calcularNovoPreco(precoAtual, amount, totalTokens, TxType.CANCEL_OFFER);
 
       transaction.update(startupRef, {
         precoToken: precoRevertido,
@@ -128,8 +127,8 @@ export async function cancelOffer(
         .collection(PRICE_HISTORY).doc();
       transaction.set(priceHistoryRef, {
         price: precoRevertido,
-        type: TX_TYPE_CANCEL_OFFER,
-        source: TX_SOURCE_SELL_OFFER,
+        type: TxType.CANCEL_OFFER,
+        source: TxSource.SELL_OFFER,
         quantity: amount,
         createdAt: FieldValue.serverTimestamp(),
       });

--- a/firebase/functions/src/modules/tokenOffers/repositories/offersRepository.ts
+++ b/firebase/functions/src/modules/tokenOffers/repositories/offersRepository.ts
@@ -7,9 +7,9 @@ import {HttpsError} from "firebase-functions/v2/https";
 import {
   USERS, STARTUPS, TOKEN_OFFERS, TRANSACTIONS,
   WALLET, WALLET_SALDO, USER_TOKENS, PRICE_HISTORY,
-  OFFER_STATUS_OPEN, TX_TYPE_BUY, TX_SOURCE_OFFER,
+  TxType, TxSource,
 } from "../../../shared/collections";
-import {FATOR_IMPACTO} from "../../../shared/tokenPricing";
+import {calcularNovoPreco} from "../../../shared/tokenPricing";
 
 import {
   BuyTokenOfferParams,
@@ -38,8 +38,8 @@ export async function listOffersBySeller(sellerId: string) {
 
   snapshot.docs.forEach((doc) => {
     const data = doc.data();
-    const status = String(data.status ?? OFFER_STATUS_OPEN);
-    if (status !== OFFER_STATUS_OPEN) {
+    const status = String(data.status ?? "open");
+    if (status !== "open") {
       return;
     }
     offers.push({
@@ -73,8 +73,8 @@ export async function listAllOffers(excludeSellerId?: string) {
 
   snapshot.docs.forEach((doc) => {
     const data = doc.data();
-    const status = String(data.status ?? OFFER_STATUS_OPEN);
-    if (status !== OFFER_STATUS_OPEN) {
+    const status = String(data.status ?? "open");
+    if (status !== "open") {
       return;
     }
     const sellerId = data.sellerId as string;
@@ -149,8 +149,8 @@ export async function buyTokenOffer(
       );
     }
 
-    const status = String(offerData.status ?? OFFER_STATUS_OPEN);
-    if (status !== OFFER_STATUS_OPEN) {
+    const status = String(offerData.status ?? "open");
+    if (status !== "open") {
       throw new HttpsError(
         "failed-precondition",
         "Oferta não está ativa"
@@ -300,8 +300,7 @@ export async function buyTokenOffer(
     if (startupData) {
       const totalTokens = Number(startupData.totalTokens ?? 1000);
       const precoAtual = Number(startupData.precoToken ?? 0);
-      const impacto = (quantity / totalTokens) * FATOR_IMPACTO;
-      const novoPreco = Math.round(precoAtual * (1 + impacto));
+      const novoPreco = calcularNovoPreco(precoAtual, quantity, totalTokens, TxType.BUY);
       transaction.update(startupRef, {
         precoToken: novoPreco,
         precoTokenAnterior: precoAtual,
@@ -312,8 +311,8 @@ export async function buyTokenOffer(
         .collection(PRICE_HISTORY).doc();
       transaction.set(priceHistoryRef, {
         price: novoPreco,
-        type: TX_TYPE_BUY,
-        source: TX_SOURCE_OFFER,
+        type: TxType.BUY,
+        source: TxSource.OFFER,
         quantity,
         createdAt: FieldValue.serverTimestamp(),
       });
@@ -328,8 +327,8 @@ export async function buyTokenOffer(
       quantity,
       pricePerTokenCents,
       totalCents,
-      type: TX_TYPE_BUY,
-      source: TX_SOURCE_OFFER,
+      type: TxType.BUY,
+      source: TxSource.OFFER,
       createdAt: FieldValue.serverTimestamp(),
     });
 

--- a/firebase/functions/src/modules/tokenOffers/repositories/sellTokenRepository.ts
+++ b/firebase/functions/src/modules/tokenOffers/repositories/sellTokenRepository.ts
@@ -6,9 +6,9 @@ import {HttpsError} from "firebase-functions/v2/https";
 import {db} from "../../../shared/firebase";
 import {
   USERS, STARTUPS, TOKEN_OFFERS, USER_TOKENS, PRICE_HISTORY,
-  OFFER_STATUS_OPEN, TX_TYPE_SELL, TX_SOURCE_SELL_OFFER,
+  TxType, TxSource,
 } from "../../../shared/collections";
-import {FATOR_IMPACTO} from "../../../shared/tokenPricing";
+import {calcularNovoPreco} from "../../../shared/tokenPricing";
 import {
   CreateSellOfferParams,
   CreateSellOfferResult,
@@ -89,7 +89,7 @@ export async function createSellOffer(
       valorUnitarioCentavos: pricePerTokenCents,
       precoMedio,
       valorAtual,
-      status: OFFER_STATUS_OPEN,
+      status: "open",
       createdAt: FieldValue.serverTimestamp(),
       updatedAt: FieldValue.serverTimestamp(),
     });
@@ -97,8 +97,7 @@ export async function createSellOffer(
     // Oferta de venda aumenta a oferta disponível → pressão de baixa no preço
     const totalTokens = Number(startupData.totalTokens ?? 1000);
     const precoAtual = Number(startupData.precoToken ?? 100);
-    const impacto = (quantity / totalTokens) * FATOR_IMPACTO;
-    const novoPreco = Math.max(1, Math.round(precoAtual * (1 - impacto)));
+    const novoPreco = calcularNovoPreco(precoAtual, quantity, totalTokens, TxType.SELL);
     transaction.update(startupRef, {
       precoToken: novoPreco,
       precoTokenAnterior: precoAtual,
@@ -109,8 +108,8 @@ export async function createSellOffer(
       .collection(PRICE_HISTORY).doc();
     transaction.set(priceHistoryRef, {
       price: novoPreco,
-      type: TX_TYPE_SELL,
-      source: TX_SOURCE_SELL_OFFER,
+      type: TxType.SELL,
+      source: TxSource.SELL_OFFER,
       quantity,
       createdAt: FieldValue.serverTimestamp(),
     });

--- a/firebase/functions/src/modules/tokenOffers/repositories/startupPurchaseRepository.ts
+++ b/firebase/functions/src/modules/tokenOffers/repositories/startupPurchaseRepository.ts
@@ -11,9 +11,9 @@ import {
   WALLET_SALDO,
   USER_TOKENS,
   PRICE_HISTORY,
-  TX_TYPE_BUY, TX_SOURCE_STARTUP,
+  TxType, TxSource,
 } from "../../../shared/collections";
-import {FATOR_IMPACTO} from "../../../shared/tokenPricing";
+import {calcularNovoPreco} from "../../../shared/tokenPricing";
 
 /**
  * @param {object} params Dados necessários para realizar a compra.
@@ -130,8 +130,7 @@ export async function buyStartupTokenDirectly(params: {
     );
 
     const totalTokens = Number(startupData.totalTokens ?? 1000);
-    const impacto = (quantity / totalTokens) * FATOR_IMPACTO;
-    const novoPreco = Math.round(pricePerTokenCents * (1 + impacto));
+    const novoPreco = calcularNovoPreco(pricePerTokenCents, quantity, totalTokens, TxType.BUY);
 
     transaction.update(startupRef, {
       tokensDisponiveis: newAvailableTokens,
@@ -142,8 +141,8 @@ export async function buyStartupTokenDirectly(params: {
 
     transaction.set(priceHistoryRef, {
       price: novoPreco,
-      type: TX_TYPE_BUY,
-      source: TX_SOURCE_STARTUP,
+      type: TxType.BUY,
+      source: TxSource.STARTUP,
       quantity,
       createdAt: FieldValue.serverTimestamp(),
     });
@@ -170,8 +169,8 @@ export async function buyStartupTokenDirectly(params: {
       quantity,
       pricePerTokenCents,
       totalCents,
-      type: TX_TYPE_BUY,
-      source: TX_SOURCE_STARTUP,
+      type: TxType.BUY,
+      source: TxSource.STARTUP,
       createdAt: FieldValue.serverTimestamp(),
     });
 

--- a/firebase/functions/src/modules/wallet/repositories/walletRepository.ts
+++ b/firebase/functions/src/modules/wallet/repositories/walletRepository.ts
@@ -6,7 +6,7 @@ import {FieldValue, Timestamp} from "firebase-admin/firestore";
 import {db} from "../../../shared/firebase";
 import {
   USERS, TRANSACTIONS, STARTUPS, WALLET, WALLET_SALDO, USER_TOKENS,
-  PRICE_HISTORY, TX_TYPE_SELL, TX_TYPE_DEPOSIT,
+  PRICE_HISTORY, TxType,
 } from "../../../shared/collections";
 
 /**
@@ -79,7 +79,7 @@ export async function getTransactionHistoryByUserId(uid: string) {
     const data = doc.data();
     return {
       id: doc.id,
-      type: TX_TYPE_SELL,
+      type: TxType.SELL,
       startupId: data.startupId ?? null,
       startupName: data.startupName ?? null,
       quantity: Number(data.quantity ?? 0),
@@ -199,7 +199,7 @@ export async function addBalanceToWallet(uid: string, amountCents: number) {
       {merge: true}
     );
     transaction.set(txRef, {
-      type: TX_TYPE_DEPOSIT,
+      type: TxType.DEPOSIT,
       buyerId: uid,
       totalCents: amountCents,
       createdAt: FieldValue.serverTimestamp(),

--- a/firebase/functions/src/shared/collections.ts
+++ b/firebase/functions/src/shared/collections.ts
@@ -16,17 +16,18 @@ export const FAQS = "faqs";
 export const PRICE_HISTORY = "priceHistory";
 export const PORTFOLIO_HISTORY = "portfolioHistory";
 
-// Status de ofertas de token
-export const OFFER_STATUS_OPEN = "open";
-
 // Tipos de transação
-export const TX_TYPE_BUY = "buy";
-export const TX_TYPE_SELL = "sell";
-export const TX_TYPE_RETURN = "return";
-export const TX_TYPE_CANCEL_OFFER = "cancel_offer";
-export const TX_TYPE_DEPOSIT = "deposit";
+export enum TxType {
+  BUY = "buy",
+  SELL = "sell",
+  RETURN = "return",
+  CANCEL_OFFER = "cancel_offer",
+  DEPOSIT = "deposit",
+}
 
 // Origem de transação
-export const TX_SOURCE_OFFER = "offer";
-export const TX_SOURCE_SELL_OFFER = "sell_offer";
-export const TX_SOURCE_STARTUP = "startup";
+export enum TxSource {
+  OFFER = "offer",
+  SELL_OFFER = "sell_offer",
+  STARTUP = "startup",
+}

--- a/firebase/functions/src/shared/tokenPricing.ts
+++ b/firebase/functions/src/shared/tokenPricing.ts
@@ -1,3 +1,24 @@
+import {TxType} from "./collections";
+
 // Fração do preço impactada a cada 100% dos tokens negociados.
-// Ex: vender 10% do total → preço muda 5% (0.10 * 0.5).
+// Ex: negociar 10% do total → preço muda 5% (0.10 * 0.5).
 export const FATOR_IMPACTO = 0.5;
+
+// Operações que aumentam o preço: compra direta, compra no balcão,
+// cancelamento de oferta (reverte o impacto da venda).
+const OPERACOES_DE_ALTA = new Set([TxType.BUY, TxType.RETURN, TxType.CANCEL_OFFER]);
+
+// Calcula o novo preço do token com base no tipo da operação.
+// Recebe o TX_TYPE da transação e determina internamente se o preço sobe ou cai.
+export function calcularNovoPreco(
+  precoAtual: number,
+  quantity: number,
+  totalTokens: number,
+  tipoOperacao: TxType
+): number {
+  const impacto = (quantity / totalTokens) * FATOR_IMPACTO;
+  const novoPreco = OPERACOES_DE_ALTA.has(tipoOperacao)
+    ? Math.round(precoAtual * (1 + impacto))
+    : Math.round(precoAtual * (1 - impacto));
+  return Math.max(1, novoPreco);
+}

--- a/frontend/lib/src/pages/private/balcao/balcao_page.dart
+++ b/frontend/lib/src/pages/private/balcao/balcao_page.dart
@@ -2,7 +2,6 @@
 // Descrição: Tela do balcão de negociação — listagem e compra de ofertas de tokens
 
 import 'package:flutter/material.dart';
-import 'package:cloud_functions/cloud_functions.dart';
 import 'package:intl/intl.dart';
 import 'package:mescla_invest/src/theme/app_colors.dart';
 import 'package:mescla_invest/src/services/wallet_service.dart';
@@ -13,7 +12,7 @@ import 'package:mescla_invest/src/pages/private/balcao/widgets/offer_card.dart';
 import 'package:mescla_invest/src/pages/private/balcao/widgets/my_order_card.dart';
 import 'package:mescla_invest/src/pages/private/balcao/widgets/user_tokens_sheet.dart';
 import 'package:mescla_invest/src/pages/private/balcao/widgets/cancel_offer_dialog.dart';
-import 'package:mescla_invest/src/pages/private/balcao/widgets/balcao_empty_state.dart';
+import 'package:mescla_invest/src/pages/private/balcao/widgets/balcao_widgets.dart';
 import 'package:mescla_invest/src/pages/private/balcao/balcao_types.dart';
 
 class BalcaoNegociacaoPage extends StatefulWidget {
@@ -21,7 +20,12 @@ class BalcaoNegociacaoPage extends StatefulWidget {
   final void Function(int)? onTabSwitch;
   final bool isActive;
 
-  const BalcaoNegociacaoPage({super.key, this.usuario, this.onTabSwitch, this.isActive = false});
+  const BalcaoNegociacaoPage({
+    super.key,
+    this.usuario,
+    this.onTabSwitch,
+    this.isActive = false,
+  });
 
   @override
   State<BalcaoNegociacaoPage> createState() => _BalcaoNegociacaoPageState();
@@ -74,7 +78,10 @@ class _BalcaoNegociacaoPageState extends State<BalcaoNegociacaoPage> {
     }..remove('');
     final entries = await Future.wait(
       names.map((name) async {
-        final url = await StorageService.getStartupAsset(name, 'logoPhoto.jpeg');
+        final url = await StorageService.getStartupAsset(
+          name,
+          'logoPhoto.jpeg',
+        );
         return MapEntry(name, url);
       }),
     );
@@ -84,25 +91,32 @@ class _BalcaoNegociacaoPageState extends State<BalcaoNegociacaoPage> {
 
   Future<void> loadOffers() async {
     if (!mounted) return;
-    setState(() { isLoadingOffers = true; offersError = null; });
-    try {
-      final result = await FirebaseFunctions.instance.httpsCallable('listOffers').call();
-      if (!mounted) return;
+    setState(() {
+      isLoadingOffers = true;
+      offersError = null;
+    });
+    final result = await WalletService.listOffers();
+    if (!mounted) return;
+    if (result['success'] == true) {
       setState(() {
-        offers = (result.data['data'] as List)
-            .map((e) => Map<String, dynamic>.from(e as Map))
-            .toList();
+        offers = List<Map<String, dynamic>>.from(result['data'] ?? []);
         isLoadingOffers = false;
       });
-    } catch (e) {
-      if (!mounted) return;
-      setState(() { offersError = 'Erro ao carregar ofertas'; isLoadingOffers = false; });
+    } else {
+      setState(() {
+        offersError =
+            result['message'] as String? ?? 'Erro ao carregar ofertas';
+        isLoadingOffers = false;
+      });
     }
   }
 
   Future<void> loadMyOffers() async {
     if (!mounted) return;
-    setState(() { isLoadingMyOffers = true; myOffersError = null; });
+    setState(() {
+      isLoadingMyOffers = true;
+      myOffersError = null;
+    });
     final result = await WalletService.listMyOffers();
     if (!mounted) return;
     setState(() {
@@ -110,7 +124,8 @@ class _BalcaoNegociacaoPageState extends State<BalcaoNegociacaoPage> {
       if (result['success'] == true) {
         myOffers = List<dynamic>.from(result['offers'] ?? []);
       } else {
-        myOffersError = result['message']?.toString() ?? 'Erro ao carregar suas ordens';
+        myOffersError =
+            result['message']?.toString() ?? 'Erro ao carregar suas ordens';
       }
     });
   }
@@ -119,18 +134,23 @@ class _BalcaoNegociacaoPageState extends State<BalcaoNegociacaoPage> {
     final list = List<dynamic>.from(myOffers);
     switch (_mySortMode) {
       case SortMode.alphabetical:
-        list.sort((a, b) =>
-            (a['startupName'] ?? a['startupId'] ?? '')
-                .toString()
-                .compareTo((b['startupName'] ?? b['startupId'] ?? '').toString()));
+        list.sort(
+          (a, b) => (a['startupName'] ?? a['startupId'] ?? '')
+              .toString()
+              .compareTo((b['startupName'] ?? b['startupId'] ?? '').toString()),
+        );
       case SortMode.priceAsc:
-        list.sort((a, b) =>
-            ((a['valorUnitarioCentavos'] as num?) ?? 0)
-                .compareTo((b['valorUnitarioCentavos'] as num?) ?? 0));
+        list.sort(
+          (a, b) => ((a['valorUnitarioCentavos'] as num?) ?? 0).compareTo(
+            (b['valorUnitarioCentavos'] as num?) ?? 0,
+          ),
+        );
       case SortMode.priceDesc:
-        list.sort((a, b) =>
-            ((b['valorUnitarioCentavos'] as num?) ?? 0)
-                .compareTo((a['valorUnitarioCentavos'] as num?) ?? 0));
+        list.sort(
+          (a, b) => ((b['valorUnitarioCentavos'] as num?) ?? 0).compareTo(
+            (a['valorUnitarioCentavos'] as num?) ?? 0,
+          ),
+        );
     }
     return list;
   }
@@ -139,27 +159,34 @@ class _BalcaoNegociacaoPageState extends State<BalcaoNegociacaoPage> {
     final q = _search.trim().toLowerCase();
     var list = q.isEmpty
         ? List<dynamic>.from(offers)
-        : offers.where((o) =>
-            (o['startupName'] ?? o['startupId'] ?? '')
-                .toString()
-                .toLowerCase()
-                .contains(q))
-            .toList();
+        : offers
+              .where(
+                (o) => (o['startupName'] ?? o['startupId'] ?? '')
+                    .toString()
+                    .toLowerCase()
+                    .contains(q),
+              )
+              .toList();
 
     switch (_sortMode) {
       case SortMode.alphabetical:
-        list.sort((a, b) =>
-            (a['startupName'] ?? a['startupId'] ?? '')
-                .toString()
-                .compareTo((b['startupName'] ?? b['startupId'] ?? '').toString()));
+        list.sort(
+          (a, b) => (a['startupName'] ?? a['startupId'] ?? '')
+              .toString()
+              .compareTo((b['startupName'] ?? b['startupId'] ?? '').toString()),
+        );
       case SortMode.priceAsc:
-        list.sort((a, b) =>
-            ((a['valorUnitarioCentavos'] as num?) ?? 0)
-                .compareTo((b['valorUnitarioCentavos'] as num?) ?? 0));
+        list.sort(
+          (a, b) => ((a['valorUnitarioCentavos'] as num?) ?? 0).compareTo(
+            (b['valorUnitarioCentavos'] as num?) ?? 0,
+          ),
+        );
       case SortMode.priceDesc:
-        list.sort((a, b) =>
-            ((b['valorUnitarioCentavos'] as num?) ?? 0)
-                .compareTo((a['valorUnitarioCentavos'] as num?) ?? 0));
+        list.sort(
+          (a, b) => ((b['valorUnitarioCentavos'] as num?) ?? 0).compareTo(
+            (a['valorUnitarioCentavos'] as num?) ?? 0,
+          ),
+        );
     }
 
     return list;
@@ -218,9 +245,7 @@ class _BalcaoNegociacaoPageState extends State<BalcaoNegociacaoPage> {
       barrierDismissible: false,
       builder: (_) => const PopScope(
         canPop: false,
-        child: Center(
-          child: CircularProgressIndicator(color: AppColors.azul),
-        ),
+        child: Center(child: CircularProgressIndicator(color: AppColors.azul)),
       ),
     );
 
@@ -260,7 +285,10 @@ class _BalcaoNegociacaoPageState extends State<BalcaoNegociacaoPage> {
           icon: const Icon(Icons.arrow_upward),
           label: const Text(
             'Criar ordem de venda',
-            style: TextStyle(fontFamily: 'JosefinSans', fontWeight: FontWeight.bold),
+            style: TextStyle(
+              fontFamily: 'JosefinSans',
+              fontWeight: FontWeight.bold,
+            ),
           ),
         ),
         appBar: AppBar(
@@ -277,7 +305,10 @@ class _BalcaoNegociacaoPageState extends State<BalcaoNegociacaoPage> {
             labelColor: AppColors.azul,
             unselectedLabelColor: AppColors.cinza500,
             indicatorColor: AppColors.azul,
-            labelStyle: TextStyle(fontFamily: 'JosefinSans', fontWeight: FontWeight.bold),
+            labelStyle: TextStyle(
+              fontFamily: 'JosefinSans',
+              fontWeight: FontWeight.bold,
+            ),
             unselectedLabelStyle: TextStyle(fontFamily: 'JosefinSans'),
             tabs: [
               Tab(text: 'Mercado'),
@@ -285,12 +316,7 @@ class _BalcaoNegociacaoPageState extends State<BalcaoNegociacaoPage> {
             ],
           ),
         ),
-        body: TabBarView(
-          children: [
-            _buildMercado(),
-            _buildMinhasOrdens(),
-          ],
-        ),
+        body: TabBarView(children: [_buildMercado(), _buildMinhasOrdens()]),
       ),
     );
   }
@@ -314,38 +340,66 @@ class _BalcaoNegociacaoPageState extends State<BalcaoNegociacaoPage> {
           child: isLoadingOffers
               ? const AppLoadingIndicator()
               : offersError != null
-                  ? Center(child: Text(offersError!, style: const TextStyle(fontFamily: 'JosefinSans', color: AppColors.cinza500)))
-                  : offers.isEmpty
-                      ? BalcaoEmptyState(message: 'Nenhuma oferta disponível no momento', icon: Icons.storefront_outlined)
-                      : filteredOffers.isEmpty
-                          ? BalcaoEmptyState(message: 'Nenhuma oferta encontrada', icon: Icons.search_off)
-                          : RefreshIndicator(
-                              onRefresh: loadOffers,
-                              child: ListView.builder(
-                                padding: const EdgeInsets.fromLTRB(20, 4, 20, 100),
-                                itemCount: filteredOffers.length,
-                                itemBuilder: (context, index) {
-                                  final data = filteredOffers[index];
-                                  final name = (data['startupName'] ?? data['startupId'] ?? '').toString();
-                                  return OfferCard(
-                                    data: data,
-                                    currency: _currency,
-                                    logoUrl: _logoUrls[name],
-                                    onTap: () async {
-                                      final comprou = await Navigator.push<bool>(context,
-                                        MaterialPageRoute(builder: (_) => BuyStepsPage(
-                                          startupName: name,
-                                          availableQuantity: int.tryParse((data['amount'] ?? 0).toString()) ?? 0,
-                                          pricePerTokenCents: int.tryParse((data['valorUnitarioCentavos'] ?? 0).toString()) ?? 0,
-                                          offerId: (data['offerId'] ?? '').toString(),
-                                        )),
-                                      );
-                                      if (comprou == true && mounted) loadOffers();
-                                    },
-                                  );
-                                },
+              ? Center(
+                  child: Text(
+                    offersError!,
+                    style: const TextStyle(
+                      fontFamily: 'JosefinSans',
+                      color: AppColors.cinza500,
+                    ),
+                  ),
+                )
+              : offers.isEmpty
+              ? BalcaoEmptyState(
+                  message: 'Nenhuma oferta disponível no momento',
+                  icon: Icons.storefront_outlined,
+                )
+              : filteredOffers.isEmpty
+              ? BalcaoEmptyState(
+                  message: 'Nenhuma oferta encontrada',
+                  icon: Icons.search_off,
+                )
+              : RefreshIndicator(
+                  onRefresh: loadOffers,
+                  child: ListView.builder(
+                    padding: const EdgeInsets.fromLTRB(20, 4, 20, 100),
+                    itemCount: filteredOffers.length,
+                    itemBuilder: (context, index) {
+                      final data = filteredOffers[index];
+                      final name =
+                          (data['startupName'] ?? data['startupId'] ?? '')
+                              .toString();
+                      return OfferCard(
+                        data: data,
+                        currency: _currency,
+                        logoUrl: _logoUrls[name],
+                        onTap: () async {
+                          final comprou = await Navigator.push<bool>(
+                            context,
+                            MaterialPageRoute(
+                              builder: (_) => BuyStepsPage(
+                                startupName: name,
+                                availableQuantity:
+                                    int.tryParse(
+                                      (data['amount'] ?? 0).toString(),
+                                    ) ??
+                                    0,
+                                pricePerTokenCents:
+                                    int.tryParse(
+                                      (data['valorUnitarioCentavos'] ?? 0)
+                                          .toString(),
+                                    ) ??
+                                    0,
+                                offerId: (data['offerId'] ?? '').toString(),
                               ),
                             ),
+                          );
+                          if (comprou == true && mounted) _loadAll();
+                        },
+                      );
+                    },
+                  ),
+                ),
         ),
       ],
     );
@@ -354,7 +408,15 @@ class _BalcaoNegociacaoPageState extends State<BalcaoNegociacaoPage> {
   Widget _buildMinhasOrdens() {
     if (isLoadingMyOffers) return const AppLoadingIndicator();
     if (myOffersError != null) {
-      return Center(child: Text(myOffersError!, style: const TextStyle(fontFamily: 'JosefinSans', color: AppColors.cinza500)));
+      return Center(
+        child: Text(
+          myOffersError!,
+          style: const TextStyle(
+            fontFamily: 'JosefinSans',
+            color: AppColors.cinza500,
+          ),
+        ),
+      );
     }
 
     return Column(
@@ -365,7 +427,12 @@ class _BalcaoNegociacaoPageState extends State<BalcaoNegociacaoPage> {
           onChanged: (mode) => setState(() => _mySortMode = mode),
         ),
         myOffers.isEmpty
-            ? Expanded(child: BalcaoEmptyState(message: 'Você não possui ordens em aberto', icon: Icons.receipt_long_outlined))
+            ? Expanded(
+                child: BalcaoEmptyState(
+                  message: 'Você não possui ordens em aberto',
+                  icon: Icons.receipt_long_outlined,
+                ),
+              )
             : Expanded(
                 child: RefreshIndicator(
                   onRefresh: loadMyOffers,
@@ -373,8 +440,12 @@ class _BalcaoNegociacaoPageState extends State<BalcaoNegociacaoPage> {
                     padding: const EdgeInsets.fromLTRB(20, 0, 20, 100),
                     itemCount: filteredMyOffers.length,
                     itemBuilder: (context, index) {
-                      final offer = Map<String, dynamic>.from(filteredMyOffers[index] as Map);
-                      final name = (offer['startupName'] ?? offer['startupId'] ?? '').toString();
+                      final offer = Map<String, dynamic>.from(
+                        filteredMyOffers[index] as Map,
+                      );
+                      final name =
+                          (offer['startupName'] ?? offer['startupId'] ?? '')
+                              .toString();
                       return Dismissible(
                         key: Key((offer['offerId'] ?? index).toString()),
                         direction: DismissDirection.endToStart,
@@ -395,5 +466,4 @@ class _BalcaoNegociacaoPageState extends State<BalcaoNegociacaoPage> {
       ],
     );
   }
-
 }

--- a/frontend/lib/src/pages/private/balcao/widgets/balcao_widgets.dart
+++ b/frontend/lib/src/pages/private/balcao/widgets/balcao_widgets.dart
@@ -91,28 +91,28 @@ class BalcaoDismissBackground extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) => Container(
-        margin: const EdgeInsets.only(bottom: 12),
-        decoration: BoxDecoration(
-          color: AppColors.vermelho,
-          borderRadius: BorderRadius.circular(12),
+    margin: const EdgeInsets.only(bottom: 12),
+    decoration: BoxDecoration(
+      color: AppColors.vermelho,
+      borderRadius: BorderRadius.circular(12),
+    ),
+    alignment: Alignment.centerRight,
+    padding: const EdgeInsets.only(right: 24),
+    child: const Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        Icon(Icons.delete_outline, color: AppColors.branco, size: 26),
+        SizedBox(height: 4),
+        Text(
+          'Cancelar',
+          style: TextStyle(
+            fontFamily: 'JosefinSans',
+            fontSize: 11,
+            fontWeight: FontWeight.bold,
+            color: AppColors.branco,
+          ),
         ),
-        alignment: Alignment.centerRight,
-        padding: const EdgeInsets.only(right: 24),
-        child: const Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            Icon(Icons.delete_outline, color: AppColors.branco, size: 26),
-            SizedBox(height: 4),
-            Text(
-              'Cancelar',
-              style: TextStyle(
-                fontFamily: 'JosefinSans',
-                fontSize: 11,
-                fontWeight: FontWeight.bold,
-                color: AppColors.branco,
-              ),
-            ),
-          ],
-        ),
-      );
+      ],
+    ),
+  );
 }

--- a/frontend/lib/src/pages/private/balcao/widgets/user_tokens_sheet.dart
+++ b/frontend/lib/src/pages/private/balcao/widgets/user_tokens_sheet.dart
@@ -18,6 +18,8 @@ class UserTokensSheet extends StatefulWidget {
 }
 
 class _UserTokensSheetState extends State<UserTokensSheet> {
+  static final _fmt = NumberFormat.currency(locale: 'pt_BR', symbol: 'R\$');
+
   List<Map<String, dynamic>> _tokens = [];
   bool _isLoading = true;
   Map<String, String?> _logoUrls = {};
@@ -44,7 +46,10 @@ class _UserTokensSheetState extends State<UserTokensSheet> {
     final entries = await Future.wait(
       _tokens.map((t) async {
         final nome = (t['startupNome'] as String?) ?? '';
-        final url = await StorageService.getStartupAsset(nome, 'logoPhoto.jpeg');
+        final url = await StorageService.getStartupAsset(
+          nome,
+          'logoPhoto.jpeg',
+        );
         return MapEntry(nome, url);
       }),
     );
@@ -90,29 +95,32 @@ class _UserTokensSheetState extends State<UserTokensSheet> {
             child: _isLoading
                 ? const AppLoadingIndicator()
                 : _tokens.isEmpty
-                    ? const Center(
-                        child: Text(
-                          'Você não possui tokens',
-                          style: TextStyle(fontFamily: 'JosefinSans', color: AppColors.cinza500),
-                        ),
-                      )
-                    : ListView.builder(
-                        controller: controller,
-                        padding: const EdgeInsets.symmetric(horizontal: 24),
-                        itemCount: _tokens.length,
-                        itemBuilder: (context, index) {
-                          final token = _tokens[index];
-                          final logoUrl = _logoUrls[token['startupNome'] as String? ?? ''];
-                          return WalletTokenCard(
-                            token: token,
-                            logoUrl: logoUrl,
-                            saldoVisivel: true,
-                            onTap: () => Navigator.pop(context, token),
-                            currencyFormat: NumberFormat.currency(
-                                locale: 'pt_BR', symbol: 'R\$'),
-                          );
-                        },
+                ? const Center(
+                    child: Text(
+                      'Você não possui tokens',
+                      style: TextStyle(
+                        fontFamily: 'JosefinSans',
+                        color: AppColors.cinza500,
                       ),
+                    ),
+                  )
+                : ListView.builder(
+                    controller: controller,
+                    padding: const EdgeInsets.symmetric(horizontal: 24),
+                    itemCount: _tokens.length,
+                    itemBuilder: (context, index) {
+                      final token = _tokens[index];
+                      final logoUrl =
+                          _logoUrls[token['startupNome'] as String? ?? ''];
+                      return WalletTokenCard(
+                        token: token,
+                        logoUrl: logoUrl,
+                        saldoVisivel: true,
+                        onTap: () => Navigator.pop(context, token),
+                        currencyFormat: _fmt,
+                      );
+                    },
+                  ),
           ),
         ],
       ),

--- a/frontend/lib/src/pages/private/catalog/widgets/startup_card.dart
+++ b/frontend/lib/src/pages/private/catalog/widgets/startup_card.dart
@@ -20,6 +20,8 @@ const Map<String, Color> estagioColors = {
 };
 
 class StartupCard extends StatelessWidget {
+  static final _fmt = NumberFormat.currency(locale: 'pt_BR', symbol: 'R\$');
+
   final String nome;
   final String setor;
   final String estagio;
@@ -43,7 +45,6 @@ class StartupCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final fmt = NumberFormat.currency(locale: 'pt_BR', symbol: 'R\$');
     final accentColor = estagioColors[estagio] ?? AppColors.azul;
     final Color precoColor;
     final double? variacaoPct;
@@ -56,8 +57,8 @@ class StartupCard extends StatelessWidget {
       precoColor = variacaoPct > 0
           ? AppColors.verde
           : variacaoPct < 0
-              ? AppColors.vermelho
-              : AppColors.cinza500;
+          ? AppColors.vermelho
+          : AppColors.cinza500;
     }
 
     final estagioChip = Container(
@@ -96,14 +97,9 @@ class StartupCard extends StatelessWidget {
                   width: double.infinity,
                   child: logoUrl != null
                       ? Image.network(logoUrl!, fit: BoxFit.cover)
-                      : Container(
-                          color: accentColor.withValues(alpha: 0.08)),
+                      : Container(color: accentColor.withValues(alpha: 0.08)),
                 ),
-                Positioned(
-                  top: 10,
-                  right: 10,
-                  child: estagioChip,
-                ),
+                Positioned(top: 10, right: 10, child: estagioChip),
               ],
             ),
             Padding(
@@ -142,7 +138,7 @@ class StartupCard extends StatelessWidget {
                         crossAxisAlignment: CrossAxisAlignment.end,
                         children: [
                           Text(
-                            fmt.format(precoToken),
+                            _fmt.format(precoToken),
                             style: TextStyle(
                               fontFamily: 'JosefinSans',
                               fontSize: 14,
@@ -175,7 +171,9 @@ class StartupCard extends StatelessWidget {
                     children: [
                       Container(
                         padding: const EdgeInsets.symmetric(
-                            horizontal: 10, vertical: 4),
+                          horizontal: 10,
+                          vertical: 4,
+                        ),
                         decoration: BoxDecoration(
                           color: AppColors.azul.withValues(alpha: 0.08),
                           borderRadius: BorderRadius.circular(20),
@@ -183,8 +181,11 @@ class StartupCard extends StatelessWidget {
                         child: Row(
                           mainAxisSize: MainAxisSize.min,
                           children: [
-                            const Icon(Icons.toll_outlined,
-                                size: 13, color: AppColors.azul),
+                            const Icon(
+                              Icons.toll_outlined,
+                              size: 13,
+                              color: AppColors.azul,
+                            ),
                             const SizedBox(width: 4),
                             Text(
                               '${NumberFormat('#,##0', 'pt_BR').format(totalTokens)} tokens',
@@ -198,12 +199,13 @@ class StartupCard extends StatelessWidget {
                           ],
                         ),
                       ),
-                      if (quantidadeToken != null &&
-                          quantidadeToken! > 0) ...[
+                      if (quantidadeToken != null && quantidadeToken! > 0) ...[
                         const Spacer(),
                         Container(
                           padding: const EdgeInsets.symmetric(
-                              horizontal: 10, vertical: 4),
+                            horizontal: 10,
+                            vertical: 4,
+                          ),
                           decoration: BoxDecoration(
                             color: AppColors.verde.withValues(alpha: 0.1),
                             borderRadius: BorderRadius.circular(20),
@@ -211,8 +213,11 @@ class StartupCard extends StatelessWidget {
                           child: Row(
                             mainAxisSize: MainAxisSize.min,
                             children: [
-                              const Icon(Icons.check_circle_outline,
-                                  size: 13, color: AppColors.verde),
+                              const Icon(
+                                Icons.check_circle_outline,
+                                size: 13,
+                                color: AppColors.verde,
+                              ),
                               const SizedBox(width: 4),
                               Text(
                                 'Você tem $quantidadeToken',

--- a/frontend/lib/src/pages/private/home/home_page.dart
+++ b/frontend/lib/src/pages/private/home/home_page.dart
@@ -21,7 +21,12 @@ class HomePage extends StatefulWidget {
   final void Function(int)? onTabSwitch;
   final bool isActive;
 
-  const HomePage({super.key, this.usuario, this.onTabSwitch, this.isActive = false});
+  const HomePage({
+    super.key,
+    this.usuario,
+    this.onTabSwitch,
+    this.isActive = false,
+  });
 
   @override
   State<HomePage> createState() => _HomePageState();
@@ -54,7 +59,9 @@ class _HomePageState extends State<HomePage> {
 
   Future<void> _loadVisibility() async {
     final prefs = await SharedPreferences.getInstance();
-    if (mounted) setState(() => _saldoVisivel = prefs.getBool('balance_visible') ?? false);
+    if (mounted) {
+      setState(() => _saldoVisivel = prefs.getBool('balance_visible') ?? false);
+    }
   }
 
   Future<void> _saveVisibility(bool value) async {
@@ -156,7 +163,9 @@ class _HomePageState extends State<HomePage> {
       _meusInvestimentos.map((data) async {
         final id = data['id'] as String? ?? '';
         final url = await StorageService.getStartupAsset(
-          data['nome'] as String? ?? '', 'logoPhoto.jpeg');
+          data['nome'] as String? ?? '',
+          'logoPhoto.jpeg',
+        );
         return MapEntry(id, url);
       }),
     );
@@ -164,32 +173,39 @@ class _HomePageState extends State<HomePage> {
     setState(() => _logoUrls = Map.fromEntries(entries));
   }
 
-
-
-
-
-
   List<Map<String, dynamic>> _portfolioHistoricoFiltrado() {
     if (_portfolioHistory.isEmpty) return [];
     final agora = DateTime.now();
-    DateTime? dataInicial;
-    switch (_selectedPeriodPortfolio) {
-      case 0: dataInicial = agora.subtract(const Duration(days: 7)); break;
-      case 1: dataInicial = agora.subtract(const Duration(days: 30)); break;
-      case 2: dataInicial = agora.subtract(const Duration(days: 180)); break;
-      case 3: dataInicial = DateTime(agora.year, 1, 1); break;
-      default: dataInicial = null;
-    }
+    final dataInicial = switch (_selectedPeriodPortfolio) {
+      0 => agora.subtract(const Duration(days: 7)),
+      1 => agora.subtract(const Duration(days: 30)),
+      2 => agora.subtract(const Duration(days: 180)),
+      3 => DateTime(agora.year, 1, 1),
+      _ => null,
+    };
     if (dataInicial == null) return _portfolioHistory;
     return _portfolioHistory.where((item) {
       final date = DateTime.tryParse(item['date']?.toString() ?? '');
       if (date == null) return false;
-      return date.isAfter(dataInicial!);
+      return date.isAfter(dataInicial);
     }).toList();
   }
 
   List<String> _labelsGraficoPortfolio() {
-    const meses = ['Jan', 'Fev', 'Mar', 'Abr', 'Mai', 'Jun', 'Jul', 'Ago', 'Set', 'Out', 'Nov', 'Dez'];
+    const meses = [
+      'Jan',
+      'Fev',
+      'Mar',
+      'Abr',
+      'Mai',
+      'Jun',
+      'Jul',
+      'Ago',
+      'Set',
+      'Out',
+      'Nov',
+      'Dez',
+    ];
     return _portfolioHistoricoFiltrado().map((item) {
       final date = DateTime.tryParse(item['date']?.toString() ?? '');
       if (date == null) return '';
@@ -209,7 +225,8 @@ class _HomePageState extends State<HomePage> {
   Color _corGraficoPortfolio() {
     final filtrado = _portfolioHistoricoFiltrado();
     if (filtrado.length < 2) return AppColors.cinza400;
-    final primeiro = (filtrado.first['returnPercent'] as num?)?.toDouble() ?? 0.0;
+    final primeiro =
+        (filtrado.first['returnPercent'] as num?)?.toDouble() ?? 0.0;
     final ultimo = (filtrado.last['returnPercent'] as num?)?.toDouble() ?? 0.0;
     if (ultimo > primeiro) return AppColors.verde;
     if (ultimo < primeiro) return AppColors.vermelho;
@@ -220,9 +237,6 @@ class _HomePageState extends State<HomePage> {
     final sinal = valor > 0 ? '+' : '';
     return '$sinal${valor.toStringAsFixed(2)}%';
   }
-
-
-
 
   @override
   Widget build(BuildContext context) {
@@ -286,20 +300,20 @@ class _HomePageState extends State<HomePage> {
             ),
 
             if (!_isLoading) ...[
-            const SizedBox(height: 28),
+              const SizedBox(height: 28),
 
-            PortfolioChartSection(
-              pontos: _gerarPontosPercentuaisPortfolio(),
-              labels: _labelsGraficoPortfolio(),
-              cor: _corGraficoPortfolio(),
-              periods: _periodsPortfolio,
-              selectedPeriod: _selectedPeriodPortfolio,
-              onPeriodChanged: (i) => setState(() => _selectedPeriodPortfolio = i),
-              formatLabel: _formatarPercentualGrafico,
-              portfolioHistory: _portfolioHistory,
-              valorPortfolio: _valorPortfolio,
-            ),
-
+              PortfolioChartSection(
+                pontos: _gerarPontosPercentuaisPortfolio(),
+                labels: _labelsGraficoPortfolio(),
+                cor: _corGraficoPortfolio(),
+                periods: _periodsPortfolio,
+                selectedPeriod: _selectedPeriodPortfolio,
+                onPeriodChanged: (i) =>
+                    setState(() => _selectedPeriodPortfolio = i),
+                formatLabel: _formatarPercentualGrafico,
+                portfolioHistory: _portfolioHistory,
+                valorPortfolio: _valorPortfolio,
+              ),
             ], // end if (!_isLoading)
 
             const SizedBox(height: 28),
@@ -329,7 +343,11 @@ class _HomePageState extends State<HomePage> {
                 child: const Center(
                   child: Column(
                     children: [
-                      Icon(Icons.business_center_outlined, size: 32, color: AppColors.cinza300),
+                      Icon(
+                        Icons.business_center_outlined,
+                        size: 32,
+                        color: AppColors.cinza300,
+                      ),
                       SizedBox(height: 8),
                       Text(
                         'Você ainda não investiu em nenhuma startup',
@@ -379,6 +397,3 @@ class _HomePageState extends State<HomePage> {
     );
   }
 }
-
-
-

--- a/frontend/lib/src/pages/private/startup_detail/startup_detail_page.dart
+++ b/frontend/lib/src/pages/private/startup_detail/startup_detail_page.dart
@@ -3,7 +3,6 @@
 // Descrição: Tela de detalhes de uma startup
 
 import 'package:flutter/material.dart';
-import 'package:cloud_functions/cloud_functions.dart';
 import 'package:mescla_invest/src/theme/app_colors.dart';
 import 'package:mescla_invest/src/services/startup_service.dart';
 import 'package:mescla_invest/src/services/faq_service.dart';
@@ -119,9 +118,11 @@ class _StartupDetailPageState extends State<StartupDetailPage> {
     if (result['success'] == true) {
       final history = List<Map<String, dynamic>>.from(result['data'] ?? []);
       history.sort((a, b) {
-        final dateA = DateTime.tryParse(a['createdAt']?.toString() ?? '') ??
+        final dateA =
+            DateTime.tryParse(a['createdAt']?.toString() ?? '') ??
             DateTime.fromMillisecondsSinceEpoch(0);
-        final dateB = DateTime.tryParse(b['createdAt']?.toString() ?? '') ??
+        final dateB =
+            DateTime.tryParse(b['createdAt']?.toString() ?? '') ??
             DateTime.fromMillisecondsSinceEpoch(0);
         return dateA.compareTo(dateB);
       });
@@ -140,17 +141,16 @@ class _StartupDetailPageState extends State<StartupDetailPage> {
       _offersLoading = true;
       _offersError = null;
     });
-    try {
-      final result = await FirebaseFunctions.instance
-          .httpsCallable('listOffers')
-          .call();
-      if (!mounted) return;
-      final list = (result.data['data'] as List? ?? [])
+    final result = await WalletService.listOffers();
+    if (!mounted) return;
+    if (result['success'] == true) {
+      final list = (result['data'] as List? ?? [])
           .map((e) => Map<String, dynamic>.from(e as Map))
           .where((o) => (o['startupId'] ?? '').toString() == widget.startupId)
           .where((o) {
             final amount = (o['amount'] as num?)?.toInt() ?? 0;
-            final unitCents = (o['valorUnitarioCentavos'] as num?)?.toInt() ?? 0;
+            final unitCents =
+                (o['valorUnitarioCentavos'] as num?)?.toInt() ?? 0;
             final offerId = (o['offerId'] ?? '').toString();
             return amount > 0 && unitCents > 0 && offerId.isNotEmpty;
           })
@@ -159,10 +159,10 @@ class _StartupDetailPageState extends State<StartupDetailPage> {
         _offers = list;
         _offersLoading = false;
       });
-    } catch (_) {
-      if (!mounted) return;
+    } else {
       setState(() {
-        _offersError = 'Erro ao carregar ofertas';
+        _offersError =
+            result['message'] as String? ?? 'Erro ao carregar ofertas';
         _offersLoading = false;
       });
     }
@@ -178,7 +178,9 @@ class _StartupDetailPageState extends State<StartupDetailPage> {
         : 0;
     setState(() {
       _userTokenQuantity = qty;
-      if (qty == 0 && _faqFilter == FaqFilter.privadas) _faqFilter = FaqFilter.todas;
+      if (qty == 0 && _faqFilter == FaqFilter.privadas) {
+        _faqFilter = FaqFilter.todas;
+      }
     });
   }
 
@@ -209,11 +211,11 @@ class _StartupDetailPageState extends State<StartupDetailPage> {
   }
 
   Future<void> _refresh() => Future.wait([
-        _initPage(),
-        _loadPriceHistory(),
-        _loadFaqs(),
-        _loadOffers(),
-      ]);
+    _initPage(),
+    _loadPriceHistory(),
+    _loadFaqs(),
+    _loadOffers(),
+  ]);
 
   void _handleOfferPurchase() {
     _houvePurchase = true;
@@ -240,7 +242,10 @@ class _StartupDetailPageState extends State<StartupDetailPage> {
   Future<void> _showFaqDialog() async {
     final result = await showDialog<FaqResult>(
       context: context,
-      builder: (_) => FaqDialog(startupId: widget.startupId, temTokens: _userTokenQuantity > 0),
+      builder: (_) => FaqDialog(
+        startupId: widget.startupId,
+        temTokens: _userTokenQuantity > 0,
+      ),
     );
     // addPostFrameCallback evita chamar setState durante a fase de build após o pop do dialog.
     if (result != null && mounted) {
@@ -272,14 +277,16 @@ class _StartupDetailPageState extends State<StartupDetailPage> {
 
     if (availableQuantity <= 0) {
       ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Essa startup não possui tokens disponíveis.')),
+        const SnackBar(
+          content: Text('Essa startup não possui tokens disponíveis.'),
+        ),
       );
       return;
     }
     if (pricePerTokenCents <= 0) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Preço do token inválido.')),
-      );
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('Preço do token inválido.')));
       return;
     }
 
@@ -318,7 +325,11 @@ class _StartupDetailPageState extends State<StartupDetailPage> {
         ),
         title: Text(
           startup?['nome'] as String? ?? widget.startupNome,
-          style: const TextStyle(color: AppColors.preto, fontSize: 22, fontWeight: FontWeight.w400),
+          style: const TextStyle(
+            color: AppColors.preto,
+            fontSize: 22,
+            fontWeight: FontWeight.w400,
+          ),
         ),
         centerTitle: true,
         actions: [
@@ -335,13 +346,18 @@ class _StartupDetailPageState extends State<StartupDetailPage> {
         mainAxisSize: MainAxisSize.min,
         children: [
           Row(
-            children: List.generate(5, (i) => Expanded(
-              child: AnimatedContainer(
-                duration: const Duration(milliseconds: 200),
-                height: 2.5,
-                color: widget.activeTabIndex == i ? AppColors.azul : AppColors.cinza200,
+            children: List.generate(
+              5,
+              (i) => Expanded(
+                child: AnimatedContainer(
+                  duration: const Duration(milliseconds: 200),
+                  height: 2.5,
+                  color: widget.activeTabIndex == i
+                      ? AppColors.azul
+                      : AppColors.cinza200,
+                ),
               ),
-            )),
+            ),
           ),
           BottomNavigationBar(
             type: BottomNavigationBarType.fixed,
@@ -355,11 +371,26 @@ class _StartupDetailPageState extends State<StartupDetailPage> {
               widget.onTabSwitch?.call(index);
             },
             items: const [
-              BottomNavigationBarItem(icon: Icon(Icons.home_outlined), label: 'Início'),
-              BottomNavigationBarItem(icon: Icon(Icons.store), label: 'Mercado'),
-              BottomNavigationBarItem(icon: Icon(Icons.list), label: 'Catálogo'),
-              BottomNavigationBarItem(icon: Icon(Icons.account_balance_wallet), label: 'Carteira'),
-              BottomNavigationBarItem(icon: Icon(Icons.person_outline), label: 'Perfil'),
+              BottomNavigationBarItem(
+                icon: Icon(Icons.home_outlined),
+                label: 'Início',
+              ),
+              BottomNavigationBarItem(
+                icon: Icon(Icons.store),
+                label: 'Mercado',
+              ),
+              BottomNavigationBarItem(
+                icon: Icon(Icons.list),
+                label: 'Catálogo',
+              ),
+              BottomNavigationBarItem(
+                icon: Icon(Icons.account_balance_wallet),
+                label: 'Carteira',
+              ),
+              BottomNavigationBarItem(
+                icon: Icon(Icons.person_outline),
+                label: 'Perfil',
+              ),
             ],
           ),
         ],
@@ -367,44 +398,48 @@ class _StartupDetailPageState extends State<StartupDetailPage> {
       body: isLoading
           ? const AppLoadingIndicator()
           : error != null
-              ? Center(child: Text('Erro: $error'))
-              : Column(
-                  children: [
-                    Expanded(
-                      child: StartupDetailContent(
-                        startup: startup!,
-                        priceHistoryLoading: _priceHistoryLoading,
-                        priceHistory: _priceHistory,
-                        selectedPeriod: _selectedPeriod,
-                        selectedSection: _selectedSection,
-                        offers: _offers,
-                        offersLoading: _offersLoading,
-                        offersError: _offersError,
-                        videoUrl: _videoUrl,
-                        summaryUrl: _summaryUrl,
-                        userTokenQuantity: _userTokenQuantity,
-                        faqsLoading: _faqsLoading,
-                        faqs: _faqs,
-                        faqFilter: _faqFilter,
-                        valorizacaoPercentual: _valorizacaoPercentual,
-                        periods: _periods,
-                        faqFilterLabels: _faqFilters,
-                        onFaqDialogOpen: _showFaqDialog,
-                        onPeriodChanged: (i) => setState(() => _selectedPeriod = PriceHistoryPeriod.values[i]),
-                        onFaqFilterChanged: (i) => setState(() => _faqFilter = FaqFilter.values[i]),
-                        onSectionChanged: (section) => setState(() => _selectedSection = section),
-                        onOffersRefresh: _loadOffers,
-                        onOfferPurchased: _handleOfferPurchase,
-                        onRefresh: _refresh,
-                      ),
+          ? Center(child: Text('Erro: $error'))
+          : Column(
+              children: [
+                Expanded(
+                  child: StartupDetailContent(
+                    startup: startup!,
+                    priceHistoryLoading: _priceHistoryLoading,
+                    priceHistory: _priceHistory,
+                    selectedPeriod: _selectedPeriod,
+                    selectedSection: _selectedSection,
+                    offers: _offers,
+                    offersLoading: _offersLoading,
+                    offersError: _offersError,
+                    videoUrl: _videoUrl,
+                    summaryUrl: _summaryUrl,
+                    userTokenQuantity: _userTokenQuantity,
+                    faqsLoading: _faqsLoading,
+                    faqs: _faqs,
+                    faqFilter: _faqFilter,
+                    valorizacaoPercentual: _valorizacaoPercentual,
+                    periods: _periods,
+                    faqFilterLabels: _faqFilters,
+                    onFaqDialogOpen: _showFaqDialog,
+                    onPeriodChanged: (i) => setState(
+                      () => _selectedPeriod = PriceHistoryPeriod.values[i],
                     ),
-                    BottomActionBar(
-                      onComprar: _openBuyStepsFromStartup,
-                      onVender: _openSellSteps,
-                      temTokens: _userTokenQuantity > 0,
-                    ),
-                  ],
+                    onFaqFilterChanged: (i) =>
+                        setState(() => _faqFilter = FaqFilter.values[i]),
+                    onSectionChanged: (section) =>
+                        setState(() => _selectedSection = section),
+                    onOffersRefresh: _loadOffers,
+                    onOfferPurchased: _handleOfferPurchase,
+                    onRefresh: _refresh,
+                  ),
                 ),
+                BottomActionBar(
+                  onComprar: _openBuyStepsFromStartup,
+                  onVender: _openSellSteps,
+                  temTokens: _userTokenQuantity > 0,
+                ),
+              ],
+            ),
     );
   }
 }

--- a/frontend/lib/src/pages/private/wallet/wallet_page.dart
+++ b/frontend/lib/src/pages/private/wallet/wallet_page.dart
@@ -19,7 +19,12 @@ class WalletPage extends StatefulWidget {
   final void Function(int)? onTabSwitch;
   final bool isActive;
 
-  const WalletPage({super.key, this.usuario, this.onTabSwitch, this.isActive = false});
+  const WalletPage({
+    super.key,
+    this.usuario,
+    this.onTabSwitch,
+    this.isActive = false,
+  });
 
   @override
   State<WalletPage> createState() => _WalletPageState();
@@ -42,8 +47,7 @@ class _WalletPageState extends State<WalletPage>
   TokenSort _tokenSort = TokenSort.alfa;
   TxFilter _txFilter = TxFilter.todos;
 
-  final currencyFormat =
-      NumberFormat.currency(locale: 'pt_BR', symbol: 'R\$');
+  final currencyFormat = NumberFormat.currency(locale: 'pt_BR', symbol: 'R\$');
 
   @override
   void didUpdateWidget(WalletPage oldWidget) {
@@ -58,14 +62,23 @@ class _WalletPageState extends State<WalletPage>
     var list = List<Map<String, dynamic>>.from(_tokens);
     switch (_tokenSort) {
       case TokenSort.alfa:
-        list.sort((a, b) => (a['startupNome'] as String? ?? '')
-            .compareTo(b['startupNome'] as String? ?? ''));
+        list.sort(
+          (a, b) => (a['startupNome'] as String? ?? '').compareTo(
+            b['startupNome'] as String? ?? '',
+          ),
+        );
       case TokenSort.precoAsc:
-        list.sort((a, b) => ((a['valorAtual'] as num?) ?? 0)
-            .compareTo((b['valorAtual'] as num?) ?? 0));
+        list.sort(
+          (a, b) => ((a['valorAtual'] as num?) ?? 0).compareTo(
+            (b['valorAtual'] as num?) ?? 0,
+          ),
+        );
       case TokenSort.precoDesc:
-        list.sort((a, b) => ((b['valorAtual'] as num?) ?? 0)
-            .compareTo((a['valorAtual'] as num?) ?? 0));
+        list.sort(
+          (a, b) => ((b['valorAtual'] as num?) ?? 0).compareTo(
+            (a['valorAtual'] as num?) ?? 0,
+          ),
+        );
     }
     return list;
   }
@@ -134,8 +147,9 @@ class _WalletPageState extends State<WalletPage>
     }
 
     if (history['success'] == true) {
-      _transactions =
-          List<Map<String, dynamic>>.from(history['transactions'] ?? []);
+      _transactions = List<Map<String, dynamic>>.from(
+        history['transactions'] ?? [],
+      );
     }
 
     if (tokens['success'] == true) {
@@ -167,8 +181,10 @@ class _WalletPageState extends State<WalletPage>
     }
     final entries = await Future.wait(
       idToNome.entries.map((e) async {
-        final url =
-            await StorageService.getStartupAsset(e.value, 'logoPhoto.jpeg');
+        final url = await StorageService.getStartupAsset(
+          e.value,
+          'logoPhoto.jpeg',
+        );
         return MapEntry(e.key, url);
       }),
     );
@@ -177,10 +193,10 @@ class _WalletPageState extends State<WalletPage>
   }
 
   double get _valorAtualPortfolio => _tokens.fold(0.0, (sum, t) {
-        final valorAtual = (t['valorAtual'] as num?)?.toDouble() ?? 0.0;
-        final quantidade = (t['quantidade'] as num?)?.toInt() ?? 0;
-        return sum + valorAtual * quantidade;
-      });
+    final valorAtual = (t['valorAtual'] as num?)?.toDouble() ?? 0.0;
+    final quantidade = (t['quantidade'] as num?)?.toInt() ?? 0;
+    return sum + valorAtual * quantidade;
+  });
 
   Future<void> _showAddBalanceDialog() async {
     final amountCents = await showDialog<int>(
@@ -214,7 +230,9 @@ class _WalletPageState extends State<WalletPage>
       saldoVisivel: _saldoVisivel,
       usuario: widget.usuario,
       onTabSwitch: widget.onTabSwitch,
-      onRefresh: () { if (mounted) _loadAll(); },
+      onRefresh: () {
+        if (mounted) _loadAll();
+      },
     );
   }
 
@@ -255,7 +273,8 @@ class _WalletPageState extends State<WalletPage>
                           logoUrls: _logoUrls,
                           saldoVisivel: _saldoVisivel,
                           tokenSort: _tokenSort,
-                          onSortChanged: (sort) => setState(() => _tokenSort = sort),
+                          onSortChanged: (sort) =>
+                              setState(() => _tokenSort = sort),
                           onTokenTap: _openTokenActions,
                           currencyFormat: currencyFormat,
                         ),
@@ -264,7 +283,8 @@ class _WalletPageState extends State<WalletPage>
                           logoUrls: _logoUrls,
                           saldoVisivel: _saldoVisivel,
                           txFilter: _txFilter,
-                          onFilterChanged: (filter) => setState(() => _txFilter = filter),
+                          onFilterChanged: (filter) =>
+                              setState(() => _txFilter = filter),
                           currencyFormat: currencyFormat,
                         ),
                       ],
@@ -299,8 +319,11 @@ class _WalletPageState extends State<WalletPage>
             const SizedBox(height: 8),
             Row(
               children: [
-                const Icon(Icons.warning_amber_rounded,
-                    size: 14, color: AppColors.laranja),
+                const Icon(
+                  Icons.warning_amber_rounded,
+                  size: 14,
+                  color: AppColors.laranja,
+                ),
                 const SizedBox(width: 6),
                 Expanded(
                   child: Text(
@@ -335,7 +358,4 @@ class _WalletPageState extends State<WalletPage>
       ),
     );
   }
-
 }
-
-

--- a/frontend/lib/src/services/wallet_service.dart
+++ b/frontend/lib/src/services/wallet_service.dart
@@ -14,11 +14,13 @@ class WalletService {
       return {
         'success': true,
         'saldo': ((result.data['saldo'] ?? 0) as num).toDouble() / 100,
-        'totalInvestido': ((result.data['totalInvestido'] ?? 0) as num).toDouble() / 100,
         'totalTokens': ((result.data['totalTokens'] ?? 0) as num).toInt(),
       };
     } on FirebaseFunctionsException catch (e) {
-      return {'success': false, 'message': e.message ?? 'Erro ao buscar carteira'};
+      return {
+        'success': false,
+        'message': e.message ?? 'Erro ao buscar carteira',
+      };
     } catch (e) {
       return {'success': false, 'message': e.toString()};
     }
@@ -37,7 +39,10 @@ class WalletService {
           .toList();
       return {'success': true, 'transactions': list};
     } on FirebaseFunctionsException catch (e) {
-      return {'success': false, 'message': e.message ?? 'Erro ao buscar histórico'};
+      return {
+        'success': false,
+        'message': e.message ?? 'Erro ao buscar histórico',
+      };
     } catch (e) {
       return {'success': false, 'message': e.toString()};
     }
@@ -45,12 +50,15 @@ class WalletService {
 
   static Future<Map<String, dynamic>> addBalance(int amountCents) async {
     try {
-      await FirebaseFunctions.instance
-          .httpsCallable('addBalance')
-          .call({'amountCents': amountCents});
+      await FirebaseFunctions.instance.httpsCallable('addBalance').call({
+        'amountCents': amountCents,
+      });
       return {'success': true};
     } on FirebaseFunctionsException catch (e) {
-      return {'success': false, 'message': e.message ?? 'Erro ao adicionar saldo'};
+      return {
+        'success': false,
+        'message': e.message ?? 'Erro ao adicionar saldo',
+      };
     } catch (e) {
       return {'success': false, 'message': e.toString()};
     }
@@ -66,7 +74,10 @@ class WalletService {
           .toList();
       return {'success': true, 'offers': list};
     } on FirebaseFunctionsException catch (e) {
-      return {'success': false, 'message': e.message ?? 'Erro ao buscar ordens'};
+      return {
+        'success': false,
+        'message': e.message ?? 'Erro ao buscar ordens',
+      };
     } catch (e) {
       return {'success': false, 'message': e.toString()};
     }
@@ -78,12 +89,17 @@ class WalletService {
     required int pricePerTokenCents,
   }) async {
     try {
-      await FirebaseFunctions.instance
-          .httpsCallable('createSellOffer')
-          .call({'startupId': startupId, 'quantity': quantity, 'pricePerTokenCents': pricePerTokenCents});
+      await FirebaseFunctions.instance.httpsCallable('createSellOffer').call({
+        'startupId': startupId,
+        'quantity': quantity,
+        'pricePerTokenCents': pricePerTokenCents,
+      });
       return {'success': true};
     } on FirebaseFunctionsException catch (e) {
-      return {'success': false, 'message': e.message ?? 'Erro ao criar ordem de venda'};
+      return {
+        'success': false,
+        'message': e.message ?? 'Erro ao criar ordem de venda',
+      };
     } catch (e) {
       return {'success': false, 'message': e.toString()};
     }
@@ -99,25 +115,23 @@ class WalletService {
           .call();
       // precoMedio e valorAtual chegam em centavos do backend.
       // Convertemos para reais aqui para que a WalletPage exiba os valores formatados.
-      final list = (result.data['tokens'] as List? ?? [])
-          .map((e) {
-            final m = Map<String, dynamic>.from(e as Map);
-            m['precoMedio'] = ((m['precoMedio'] as num?) ?? 0) / 100.0;
-            m['valorAtual'] = ((m['valorAtual'] as num?) ?? 0) / 100.0;
-            m['precoAnterior'] = ((m['precoAnterior'] as num?) ?? 0) / 100.0;
-            return m;
-          })
-          .toList();
+      final list = (result.data['tokens'] as List? ?? []).map((e) {
+        final m = Map<String, dynamic>.from(e as Map);
+        m['precoMedio'] = ((m['precoMedio'] as num?) ?? 0) / 100.0;
+        m['valorAtual'] = ((m['valorAtual'] as num?) ?? 0) / 100.0;
+        m['precoAnterior'] = ((m['precoAnterior'] as num?) ?? 0) / 100.0;
+        return m;
+      }).toList();
       return {'success': true, 'tokens': list};
     } on FirebaseFunctionsException catch (e) {
-      return {'success': false, 'message': e.message ?? 'Erro ao buscar tokens'};
+      return {
+        'success': false,
+        'message': e.message ?? 'Erro ao buscar tokens',
+      };
     } catch (e) {
       return {'success': false, 'message': e.toString()};
     }
   }
-
-
-
 
   static Future<Map<String, dynamic>> getPortfolioHistory() async {
     try {
@@ -129,35 +143,43 @@ class WalletService {
           .map((e) => Map<String, dynamic>.from(e as Map))
           .toList();
 
-      return {
-        'success': true,
-        'points': list,
-      };
+      return {'success': true, 'points': list};
     } on FirebaseFunctionsException catch (e) {
       return {
         'success': false,
         'message': e.message ?? 'Erro ao buscar histórico do portfólio',
       };
     } catch (e) {
-      return {
-        'success': false,
-        'message': e.toString(),
-      };
+      return {'success': false, 'message': e.toString()};
     }
   }
 
-
-
-
-
-
-
+  static Future<Map<String, dynamic>> listOffers() async {
+    try {
+      final result = await FirebaseFunctions.instance
+          .httpsCallable('listOffers')
+          .call();
+      return {
+        'success': true,
+        'data': (result.data['data'] as List? ?? [])
+            .map((e) => Map<String, dynamic>.from(e as Map))
+            .toList(),
+      };
+    } on FirebaseFunctionsException catch (e) {
+      return {
+        'success': false,
+        'message': e.message ?? 'Erro ao carregar ofertas',
+      };
+    } catch (e) {
+      return {'success': false, 'message': e.toString()};
+    }
+  }
 
   static Future<Map<String, dynamic>> cancelOffer(String offerId) async {
     try {
-      await FirebaseFunctions.instance
-          .httpsCallable('cancelOffer')
-          .call({'offerId': offerId});
+      await FirebaseFunctions.instance.httpsCallable('cancelOffer').call({
+        'offerId': offerId,
+      });
 
       return {'success': true};
     } on FirebaseFunctionsException catch (e) {

--- a/frontend/lib/src/widgets/finance/saldo_display.dart
+++ b/frontend/lib/src/widgets/finance/saldo_display.dart
@@ -6,6 +6,8 @@ import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
 class SaldoDisplay extends StatelessWidget {
+  static final _fmt = NumberFormat.currency(locale: 'pt_BR', symbol: 'R\$');
+
   final double saldo;
   final bool visivel;
   final String label;
@@ -29,7 +31,6 @@ class SaldoDisplay extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final fmt = NumberFormat.currency(locale: 'pt_BR', symbol: 'R\$');
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -47,7 +48,9 @@ class SaldoDisplay extends StatelessWidget {
             GestureDetector(
               onTap: () => onVisibilityChanged?.call(!visivel),
               child: Icon(
-                visivel ? Icons.visibility_outlined : Icons.visibility_off_outlined,
+                visivel
+                    ? Icons.visibility_outlined
+                    : Icons.visibility_off_outlined,
                 size: 20,
                 color: eyeColor,
               ),
@@ -56,7 +59,7 @@ class SaldoDisplay extends StatelessWidget {
         ),
         const SizedBox(height: 8),
         Text(
-          visivel ? fmt.format(saldo) : 'R\$ ••••••',
+          visivel ? _fmt.format(saldo) : 'R\$ ••••••',
           style: TextStyle(
             fontFamily: 'JosefinSans',
             fontSize: balanceFontSize,


### PR DESCRIPTION
Backend:
- Extrai calcularNovoPreco para shared/tokenPricing.ts, eliminando fórmula duplicada em 4 repositories
- Converte TX_TYPE_* e TX_SOURCE_* para enums TxType e TxSource em collections.ts
- Todos os repositories usam os enums e a função centralizada

Frontend:
- Corrige balcao_page: chama _loadAll() após compra (logos e minhas ordens não atualizavam)
- Renomeia balcao_empty_state.dart para balcao_widgets.dart
- Move NumberFormat.currency para static final em startup_card, saldo_display e user_tokens_sheet (evita recriar instância a cada rebuild)
- Corrige home_page: switch Dart 3, remove dataInicial! unsafe, curly braces
- Corrige startup_detail_page: curly braces em if sem bloco
- Remove totalInvestido redundante do WalletService (frontend recalculava o mesmo valor já presente nos tokens)